### PR TITLE
Avoid confusing modules with executables in bin

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import codecs
 import copy
 import os
+import os.path
 from sys import path as PYTHONPATH
 from sys import stderr
 
@@ -120,7 +121,8 @@ class SortImports(object):
         for prefix in PYTHONPATH:
             fixed_module_name = moduleName.replace('.', '/')
             base_path = prefix + "/" + fixed_module_name
-            if os.path.exists(base_path + ".py") or os.path.exists(base_path) or os.path.exists(base_path + ".so"):
+            if (os.path.exists(base_path + ".py") or os.path.exists(base_path + ".so") or
+                (os.path.exists(base_path) and os.path.isdir(base_path))):
                 if "site-packages" in prefix or "dist-packages" in prefix:
                     return Sections.THIRDPARTY
                 elif "python2" in prefix.lower() or "python3" in prefix.lower():


### PR DESCRIPTION
When an imported module shares the same name as an executable in the isort script's dir, isort will no longer classify it as a first-party module, even if bin appears before site-packages in sys.path

E.g. this is a problem for modules such as gunicorn (because it also installs a script named "gunicorn"), but only when isort has been installed (if running it out of its source dir, it doesn't see the gunicorn executable)
