### PR TITLE
Update the README to showcase the same-line sorting ability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Before isort:
 
     import os
 
+    from my_lib import Object3
+
     from my_lib import Object2
 
     import sys
 
-    from third_party import lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9, lib10, lib11, lib12, lib13, lib14, lib15
+    from third_party import lib15, lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9, lib10, lib11, lib12, lib13, lib14
 
     import sys
 
@@ -41,7 +43,7 @@ After isort:
     from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8,
                              lib9, lib10, lib11, lib12, lib13, lib14, lib15)
 
-    from my_lib import Object, Object2
+    from my_lib import Object, Object2, Object3
 
     print("Hey")
     print("yo")


### PR DESCRIPTION
The before/after example does not cover the library's ability to sort on the same import line. For instance, just by looking at the example I was not sure if it would sort imports such as "from third_party import lib3, lib2, lib1" or if it would leave them as they were.
