### PR TITLE
fix docstring bug

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -3,7 +3,7 @@
 Defines how the default settings for isort should be loaded
 
 (First from the default setting dictionary at the top of the file, then overridden by any settings
- in ~/.isort.conf if there are any)
+ in ~/.isort.cfg if there are any)
 
 Copyright (C) 2013  Timothy Edmund Crosley
 


### PR DESCRIPTION
The module docstring specifies the config file is at ~/.isort.conf but the code looks in ~/.isort.cfg, hence I spent a long time trying to figure out why my config file was silently being ignored!
