### PR TITLE
Fix line split for as imports.

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -307,7 +307,8 @@ class SortImports(object):
                         if self.config['combine_as_imports'] and not "*" in from_imports:
                             from_imports[from_imports.index(from_import)] = import_definition
                         else:
-                            section_output.append(import_start + import_definition)
+                            import_statement = self._wrap(import_start + import_definition)
+                            section_output.append(import_statement)
                             from_imports.remove(from_import)
 
                 if from_imports:

--- a/test_isort.py
+++ b/test_isort.py
@@ -786,6 +786,16 @@ def test_combined_from_and_as_imports():
     assert SortImports(file_contents=test_input, combine_as_imports=True).output == test_input
 
 
+def test_as_imports_with_line_length():
+    """Test to ensure it's possible to combine from and as imports."""
+    test_input = ("from translate.storage import base as storage_base\n"
+                  "from translate.storage.placeables import general, parse as rich_parse\n")
+    assert SortImports(file_contents=test_input, combine_as_imports=False, line_length=40).output == \
+                  ("from translate. \\\n    storage import base as storage_base\n"
+                  "from translate.storage. \\\n    placeables import parse as rich_parse\n"
+                  "from translate.storage. \\\n    placeables import general\n")
+
+
 def test_keep_comments():
     """Test to ensure isort properly keeps comments in tact after sorting."""
     # Straight Import


### PR DESCRIPTION
as imports are not split when to long.
