### PR TITLE
Avoid truncating module names without a period

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -183,10 +183,9 @@ class SortImports(object):
         if moduleName.startswith("."):
             return SECTIONS.LOCALFOLDER
 
-        index = moduleName.find('.')
-        if index:
-            firstPart = moduleName[:index]
-        else:
+        try:
+            firstPart = moduleName.split('.')[0]
+        except IndexError:
             firstPart = None
 
         for forced_separate in self.config['forced_separate']:


### PR DESCRIPTION
When sorting a file with a third party library that is similarly named to a
standard library module  in this case) the `index` variable was set to `-1`
which evaluates to `True` in the conditional thus truncating the last
character from the moduleName. In the case of times [1] you end up with
firstPart being `time`, a standard library module.

Tested with these imports:

```
import times

import datetime

import requests
```

Running isort 3.7.0 on python 2.7.6.

1: https://pypi.python.org/pypi/times
