### PR TITLE
Stop looking for config files once we hit the filesystem root.

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -107,7 +107,10 @@ def _update_settings_with_config(path, name, default, sections, computed_setting
             editor_config_file = potential_path
             break
 
-        current_directory = os.path.split(current_directory)[0]
+        new_directory = os.path.split(current_directory)[0]
+        if current_directory == new_directory:
+            break
+        current_directory = new_directory
         tries += 1
 
     if editor_config_file and os.path.exists(editor_config_file):


### PR DESCRIPTION
While playing around trying to understand what was happening in #166, I noticed that isort is missing a shortcut when (failing) to find config files.
