### PR TITLE
Added show_diff to config

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -147,7 +147,7 @@ class SortImports(object):
                 self.incorrectly_sorted = True
             return
 
-        if show_diff:
+        if show_diff or self.config.get('show_diff', False) is True:
             for line in unified_diff(file_contents.splitlines(1), self.output.splitlines(1),
                                      fromfile=self.file_path + ':before', tofile=self.file_path + ':after'):
                 stdout.write(line)


### PR DESCRIPTION
We're using isort with our (pre-commit-hook)[https://github.com/FalconSocial/pre-commit-python-sorter] and would like to be able to use show_diff in the settings file, keeping it out of the code if possible :)
