### PR TITLE
Add config for known future library imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ To configure isort for a single user create a ~/.isort.cfg file:
     line_length=120
     force_to_top=file1.py,file2.py
     skip=file3.py,file4.py
+    known_future_library=future,pies
     known_standard_library=std,std2
     known_third_party=randomthirdparty
     known_first_party=mylib1,mylib2

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -194,7 +194,8 @@ class SortImports(object):
             if moduleName.startswith(forced_separate):
                 return forced_separate
 
-        if moduleName == "__future__" or (firstPart == "__future__"):
+        if (moduleName in self.config['known_future_library'] or
+                firstPart in self.config['known_future_library']):
             return SECTIONS.FUTURE
         elif moduleName in self.config['known_standard_library'] or \
                 (firstPart in self.config['known_standard_library']):

--- a/isort/main.py
+++ b/isort/main.py
@@ -52,6 +52,8 @@ def main():
                         dest='not_skip', action='append')
     parser.add_argument('-t', '--top', help='Force specific imports to the top of their appropriate section.',
                         dest='force_to_top', action='append')
+    parser.add_argument('-f', '--future', dest='known_future_library', action='append',
+                        help='Force sortImports to recognize a module as part of the future compatibility libraries.')
     parser.add_argument('-b', '--builtin', dest='known_standard_library', action='append',
                         help='Force sortImports to recognize a module as part of the python standard library.')
     parser.add_argument('-o', '--thirdparty', dest='known_third_party', action='append',

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -44,6 +44,7 @@ WrapModes = namedtuple('WrapModes', WrapModes)(*range(len(WrapModes)))
 default = {'force_to_top': [],
            'skip': ['__init__.py', ],
            'line_length': 79,
+           'known_future_library': ['__future__'],
            'known_standard_library': ["abc", "anydbm", "argparse", "array", "asynchat", "asyncore", "atexit", "base64",
                                       "BaseHTTPServer", "bisect", "bz2", "calendar", "cgitb", "cmd", "codecs",
                                       "collections", "commands", "compileall", "ConfigParser", "contextlib", "Cookie",


### PR DESCRIPTION
If you're using something like `future` or `pies`, you may want to put those imports together with the `__future__` ones. Normally, these would probably be third-party, but the `__fuure__` location is neither first-party, nor standard library.
