### PR TITLE
Update timothycrosley references to pycqa

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -5,7 +5,7 @@
         "cookiecutter": {
             "full_name": "Timothy Crosley",
             "email": "timothy.crosley@gmail.com",
-            "github_username": "timothycrosley",
+            "github_username": "pycqa",
             "project_name": "isort",
             "description": "A Python utility / library to sort Python imports.",
             "version": "4.3.21",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/pycqa/isort
     rev: 5.3.0
     hooks:
       - id: isort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ Internal Development:
   - Added warning for deprecated CLI flags and linked to upgrade guide.
 
 ### 5.0.3 - July 4, 2020
-  - Fixed setup.py command incorrectly passing check=True as a configuration parameter (see: https://github.com/timothycrosley/isort/issues/1258)
+  - Fixed setup.py command incorrectly passing check=True as a configuration parameter (see: https://github.com/pycqa/isort/issues/1258)
   - Fixed missing patch version
   - Fixed issue #1253: Atomic fails when passed in not readable output stream
 
@@ -177,7 +177,7 @@ Internal:
 
 - profile support for common project types (black, django, google, etc)
 
-- Much much more. There is some difficulty in fully capturing the extent of changes in this release - just because of how all encompassing the release is. See: [Github Issues](https://github.com/timothycrosley/isort/issues?q=is%3Aissue+is%3Aclosed) for more.
+- Much much more. There is some difficulty in fully capturing the extent of changes in this release - just because of how all encompassing the release is. See: [Github Issues](https://github.com/pycqa/isort/issues?q=is%3Aissue+is%3Aclosed) for more.
 
 ### 4.3.21 - June 25, 2019 - hot fix release
 - Fixed issue #957 - Long aliases and use_parentheses generates invalid syntax

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 [![Code coverage Status](https://codecov.io/gh/pycqa/isort/branch/develop/graph/badge.svg)](https://codecov.io/gh/pycqa/isort)
 [![Maintainability](https://api.codeclimate.com/v1/badges/060372d3e77573072609/maintainability)](https://codeclimate.com/github/timothycrosley/isort/maintainability)
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://pypi.org/project/isort/)
-[![Join the chat at https://gitter.im/pycqa/isort](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pycqa/isort?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/timothycrosley/isort](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/timothycrosley/isort?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Downloads](https://pepy.tech/badge/isort)](https://pepy.tech/project/isort)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-[![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/pycqa/isort/?ref=repository-badge)
+[![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/timothycrosley/isort/?ref=repository-badge)
 _________________
 
 [Read Latest Documentation](https://pycqa.github.io/isort/) - [Browse GitHub Code Repository](https://github.com/pycqa/isort/)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-[![isort - isort your imports, so you don't have to.](https://raw.githubusercontent.com/timothycrosley/isort/develop/art/logo_large.png)](https://timothycrosley.github.io/isort/)
+[![isort - isort your imports, so you don't have to.](https://raw.githubusercontent.com/pycqa/isort/develop/art/logo_large.png)](https://pycqa.github.io/isort/)
 
 ------------------------------------------------------------------------
 
 [![PyPI version](https://badge.fury.io/py/isort.svg)](https://badge.fury.io/py/isort)
-[![Test Status](https://github.com/timothycrosley/isort/workflows/Test/badge.svg?branch=develop)](https://github.com/timothycrosley/isort/actions?query=workflow%3ATest)
-[![Lint Status](https://github.com/timothycrosley/isort/workflows/Lint/badge.svg?branch=develop)](https://github.com/timothycrosley/isort/actions?query=workflow%3ALint)
-[![Code coverage Status](https://codecov.io/gh/timothycrosley/isort/branch/develop/graph/badge.svg)](https://codecov.io/gh/timothycrosley/isort)
+[![Test Status](https://github.com/pycqa/isort/workflows/Test/badge.svg?branch=develop)](https://github.com/pycqa/isort/actions?query=workflow%3ATest)
+[![Lint Status](https://github.com/pycqa/isort/workflows/Lint/badge.svg?branch=develop)](https://github.com/pycqa/isort/actions?query=workflow%3ALint)
+[![Code coverage Status](https://codecov.io/gh/pycqa/isort/branch/develop/graph/badge.svg)](https://codecov.io/gh/pycqa/isort)
 [![Maintainability](https://api.codeclimate.com/v1/badges/060372d3e77573072609/maintainability)](https://codeclimate.com/github/timothycrosley/isort/maintainability)
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://pypi.org/project/isort/)
-[![Join the chat at https://gitter.im/timothycrosley/isort](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/timothycrosley/isort?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/pycqa/isort](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pycqa/isort?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Downloads](https://pepy.tech/badge/isort)](https://pepy.tech/project/isort)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://timothycrosley.github.io/isort/)
-[![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/timothycrosley/isort/?ref=repository-badge)
+[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+[![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/pycqa/isort/?ref=repository-badge)
 _________________
 
-[Read Latest Documentation](https://timothycrosley.github.io/isort/) - [Browse GitHub Code Repository](https://github.com/timothycrosley/isort/)
+[Read Latest Documentation](https://pycqa.github.io/isort/) - [Browse GitHub Code Repository](https://github.com/pycqa/isort/)
 _________________
 
 isort your imports, so you don't have to.
@@ -23,13 +23,13 @@ isort your imports, so you don't have to.
 isort is a Python utility / library to sort imports alphabetically, and
 automatically separated into sections and by type. It provides a command line
 utility, Python library and [plugins for various
-editors](https://github.com/timothycrosley/isort/wiki/isort-Plugins) to
+editors](https://github.com/pycqa/isort/wiki/isort-Plugins) to
 quickly sort all your imports. It requires Python 3.6+ to run but
 supports formatting Python 2 code too.
 
-[Try isort now from your browser!](https://timothycrosley.github.io/isort/docs/quick_start/0.-try/)
+[Try isort now from your browser!](https://pycqa.github.io/isort/docs/quick_start/0.-try/)
 
-![Example Usage](https://raw.github.com/timothycrosley/isort/develop/example.gif)
+![Example Usage](https://raw.github.com/pycqa/isort/develop/example.gif)
 
 Before isort:
 
@@ -155,7 +155,7 @@ sorted_code = isort.code("import b\nimport a\n")
 
 Several plugins have been written that enable to use isort from within a
 variety of text-editors. You can find a full list of them [on the isort
-wiki](https://github.com/timothycrosley/isort/wiki/isort-Plugins).
+wiki](https://github.com/pycqa/isort/wiki/isort-Plugins).
 Additionally, I will enthusiastically accept pull requests that include
 plugins for other text editors and add documentation for them as I am
 notified.
@@ -443,7 +443,7 @@ import b
 from a import a  # This will always appear below because it is a from import.
 ```
 
-However, if you prefer to keep strict alphabetical sorting you can set [force sort within sections](https://timothycrosley.github.io/isort/docs/configuration/options/#force-sort-within-sections) to true. Resulting in:
+However, if you prefer to keep strict alphabetical sorting you can set [force sort within sections](https://pycqa.github.io/isort/docs/configuration/options/#force-sort-within-sections) to true. Resulting in:
 
 
 ```python
@@ -451,7 +451,7 @@ from a import a  # This will now appear at top because a appears in the alphabet
 import b
 ```
 
-You can even tell isort to always place from imports on top, instead of the default of placing them on bottom, using [from first](https://timothycrosley.github.io/isort/docs/configuration/options/#from-first).
+You can even tell isort to always place from imports on top, instead of the default of placing them on bottom, using [from first](https://pycqa.github.io/isort/docs/configuration/options/#from-first).
 
 ```python
 from b import b # If from first is set to True, all from imports will be placed before non-from imports.
@@ -608,21 +608,21 @@ setup(
 
 ## Spread the word
 
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://timothycrosley.github.io/isort/)
+[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 
 Place this badge at the top of your repository to let others know your project uses isort.
 
 For README.md:
 
 ```markdown
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://timothycrosley.github.io/isort/)
+[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 ```
 
 Or README.rst:
 
 ```rst
 .. image:: https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336
-    :target: https://timothycrosley.github.io/isort/
+    :target: https://pycqa.github.io/isort/
 ```
 
 ## Security contact information

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -4,7 +4,7 @@ As a code formatter isort has opinions. However, it also allows you to have your
 isort will disagree but commit to your way of formatting. To enable this, isort exposes a plethora of options to specify
 how you want your imports sorted, organized, and formatted.
 
-Too busy to build your perfect isort configuration? For curated common configurations, see isort's [built-in profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/).
+Too busy to build your perfect isort configuration? For curated common configurations, see isort's [built-in profiles](https://pycqa.github.io/isort/docs/configuration/profiles/).
 
 ## Python Version
 

--- a/docs/contributing/1.-contributing-guide.md
+++ b/docs/contributing/1.-contributing-guide.md
@@ -21,7 +21,7 @@ Base System Requirements:
 
 Once you have verified that your system matches the base requirements you can start to get the project working by following these steps:
 
-1. [Fork the project on GitHub](https://github.com/timothycrosley/isort/fork).
+1. [Fork the project on GitHub](https://github.com/pycqa/isort/fork).
 2. Clone your fork to your local file system:
     `git clone https://github.com/$GITHUB_ACCOUNT/isort.git`
 3. `cd isort`
@@ -57,10 +57,10 @@ A local test cycle might look like the following:
 ## Making a contribution
 Congrats! You're now ready to make a contribution! Use the following as a guide to help you reach a successful pull-request:
 
-1. Check the [issues page](https://github.com/timothycrosley/isort/issues) on GitHub to see if the task you want to complete is listed there.
+1. Check the [issues page](https://github.com/pycqa/isort/issues) on GitHub to see if the task you want to complete is listed there.
     - If it's listed there, write a comment letting others know you are working on it.
     - If it's not listed in GitHub issues, go ahead and log a new issue. Then add a comment letting everyone know you have it under control.
-        - If you're not sure if it's something that is good for the main isort project and want immediate feedback, you can discuss it [here](https://gitter.im/timothycrosley/isort).
+        - If you're not sure if it's something that is good for the main isort project and want immediate feedback, you can discuss it [here](https://gitter.im/pycqa/isort).
 2. Create an issue branch for your local work `git checkout -b issue/$ISSUE-NUMBER`.
 3. Do your magic here.
 4. Ensure your code matches the [HOPE-8 Coding Standard](https://github.com/hugapi/HOPE/blob/master/all/HOPE-8--Style-Guide-for-Hug-Code.md#hope-8----style-guide-for-hug-code) used by the project.

--- a/docs/major_releases/introducing_isort_5.md
+++ b/docs/major_releases/introducing_isort_5.md
@@ -1,16 +1,16 @@
 # Introducing isort 5
 
-[![isort 5 - the best version of isort yet](https://raw.githubusercontent.com/timothycrosley/isort/develop/art/logo_5.png)](https://timothycrosley.github.io/isort/)
+[![isort 5 - the best version of isort yet](https://raw.githubusercontent.com/pycqa/isort/develop/art/logo_5.png)](https://pycqa.github.io/isort/)
 
 isort 5.0.0 is the first major release of isort in over five years and the first significant refactoring of isort since it was conceived more than ten years ago.
 It's also the first version to require Python 3 (Python 3.6+ at that!) to run - though it can still be run on source files from any version of Python.
 This does mean that there may be some pain with the upgrade process, but we believe the improvements will be well worth it.
 
-[Click here for an attempt at full changelog with a list of breaking changes.](https://timothycrosley.github.io/isort/CHANGELOG/)
+[Click here for an attempt at full changelog with a list of breaking changes.](https://pycqa.github.io/isort/CHANGELOG/)
 
-[Using isort 4.x.x? Click here for the isort 5.0.0 upgrade guide.](https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/)
+[Using isort 4.x.x? Click here for the isort 5.0.0 upgrade guide.](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/)
 
-[Try isort 5 right now from your browser!](https://timothycrosley.github.io/isort/docs/quick_start/0.-try/)
+[Try isort 5 right now from your browser!](https://pycqa.github.io/isort/docs/quick_start/0.-try/)
 
 So why the massive change?
 
@@ -105,7 +105,7 @@ import c
 import d
 ```
 
-isort 5 adds support for [Action Comments](https://timothycrosley.github.io/isort/docs/configuration/action_comments/) which provide a quick and convient way to control the flow of parsing within single source files.
+isort 5 adds support for [Action Comments](https://pycqa.github.io/isort/docs/configuration/action_comments/) which provide a quick and convient way to control the flow of parsing within single source files.
 
 
 # First class Python API
@@ -122,21 +122,21 @@ import b
 """
 ```
 
-isort now exposes its programmatic API as a first-class citizen. This API makes it easy to extend or use isort in your own Python project. You can see the full documentation for this new API [here](https://timothycrosley.github.io/isort/reference/isort/api/).
+isort now exposes its programmatic API as a first-class citizen. This API makes it easy to extend or use isort in your own Python project. You can see the full documentation for this new API [here](https://pycqa.github.io/isort/reference/isort/api/).
 
 # Solid base for the future
 
 A major focus for the release was to give isort a solid foundation for the next 5-10 years of the project's life.
 isort has been refactored into functional components that are easily testable. The project now has 100% code coverage.
 It utilizes tools like [Hypothesis](https://hypothesis.readthedocs.io/en/latest/) to reduce the number of unexpected errors.
-It went from fully dynamic to fully static typing using mypy. Finally, it utilizes the latest linters both on (like [DeepSource](https://deepsource.io/gh/timothycrosley/isort/)) and offline (like [Flake8](https://flake8.pycqa.org/en/latest/)) to help ensure a higher bar for all code contributions into the future.
+It went from fully dynamic to fully static typing using mypy. Finally, it utilizes the latest linters both on (like [DeepSource](https://deepsource.io/gh/pycqa/isort/)) and offline (like [Flake8](https://flake8.pycqa.org/en/latest/)) to help ensure a higher bar for all code contributions into the future.
 
 # Give 5.0.0 a try!
 
-[Try isort 5 right now from your browser!](https://timothycrosley.github.io/isort/docs/quick_start/0.-try/)
+[Try isort 5 right now from your browser!](https://pycqa.github.io/isort/docs/quick_start/0.-try/)
 
 OR
 
 Install isort locally using `pip3 install isort`.
 
-[Click here for full installation instructions.](https://timothycrosley.github.io/isort/docs/quick_start/1.-install/)
+[Click here for full installation instructions.](https://pycqa.github.io/isort/docs/quick_start/1.-install/)

--- a/docs/quick_start/0.-try.md
+++ b/docs/quick_start/0.-try.md
@@ -13,7 +13,7 @@ Use our live isort editor to see how isort can help improve the formatting of yo
 </script>
 <script src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
 <script src="https://pagecdn.io/lib/ace/1.4.5/ace.js" integrity="sha256-5Xkhn3k/1rbXB+Q/DX/2RuAtaB4dRRyQvMs83prFjpM=" crossorigin="anonymous"></script>
-<link rel="stylesheet" type="text/css" href="https://timothycrosley.github.io/isort/docs/quick_start/interactive.css">
+<link rel="stylesheet" type="text/css" href="https://pycqa.github.io/isort/docs/quick_start/interactive.css">
 </head>
 
 
@@ -32,7 +32,7 @@ import b, a
 <div id="outputEditor" class="editor">Loading...</div>
 <div>
 
-&nbsp;Configuration (Note: the below must follow JSON format). Full configuration guide is <a href="https://timothycrosley.github.io/isort/docs/configuration/options/">here</a>:
+&nbsp;Configuration (Note: the below must follow JSON format). Full configuration guide is <a href="https://pycqa.github.io/isort/docs/configuration/options/">here</a>:
 
 <div id="configEditor" class="configurator">{"line_length": 80,
  "profile": "black",
@@ -43,8 +43,8 @@ import b, a
 </div>
 </div>
 
-<script src="https://timothycrosley.github.io/isort/docs/quick_start/interactive.js"></script>
+<script src="https://pycqa.github.io/isort/docs/quick_start/interactive.js"></script>
 <div style="clear:both;"></div>
 Like what you saw? Installing isort to use locally is as simple as `pip3 install isort`.
 
-[Click here for full installation instructions.](https://timothycrosley.github.io/isort/docs/quick_start/1.-install/)
+[Click here for full installation instructions.](https://pycqa.github.io/isort/docs/quick_start/1.-install/)

--- a/docs/quick_start/2.-cli.md
+++ b/docs/quick_start/2.-cli.md
@@ -3,7 +3,7 @@
 Once installed, `isort` exposes a command line utility for sorting, organizing, and formatting imports within Python and Cython source files.
 
 To verify the tool is installed correctly, run `isort` from the command line and you should be given the available commands and the version of isort installed.
-For a list of all CLI options type `isort --help` or view [the online configuration reference](https://timothycrosley.github.io/isort/docs/configuration/options/):
+For a list of all CLI options type `isort --help` or view [the online configuration reference](https://pycqa.github.io/isort/docs/configuration/options/):
 
 <script id="asciicast-346599" src="https://asciinema.org/a/346599.js" async></script>
 

--- a/docs/quick_start/3.-api.md
+++ b/docs/quick_start/3.-api.md
@@ -19,4 +19,4 @@ Highlights include:
 - `isort.place_module` - Takes the name of a module as a string and returns the categorization determined for it.
 - `isort.place_module_with_reason` - Takes the name of a module as a string and returns the categorization determined for it and why that categorization was given.
 
-For a full definition of the API see the [API reference documentation](https://timothycrosley.github.io/isort/reference/isort/api/) or try `help(isort)` from an interactive interpreter.
+For a full definition of the API see the [API reference documentation](https://pycqa.github.io/isort/reference/isort/api/) or try `help(isort)` from an interactive interpreter.

--- a/docs/upgrade_guides/5.0.0.md
+++ b/docs/upgrade_guides/5.0.0.md
@@ -5,8 +5,8 @@ This guide is meant to help migrate projects from using isort 4.x.x unto the 5.0
 
 Related documentation:
 
-* [isort 5.0.0 changelog](https://timothycrosley.github.io/isort/CHANGELOG/#500-penny-july-4-2020)
-* [isort 5 release document](https://timothycrosley.github.io/isort/docs/major_releases/introducing_isort_5/)
+* [isort 5.0.0 changelog](https://pycqa.github.io/isort/CHANGELOG/#500-penny-july-4-2020)
+* [isort 5 release document](https://pycqa.github.io/isort/docs/major_releases/introducing_isort_5/)
 
 !!! important - "If you use pre-commit remove seed-isort-config."
     If you currently use pre-commit, make sure to see the pre-commit section of this document. In particular, make sure to remove any `seed-isort-config` pre-step.
@@ -19,7 +19,7 @@ for those of us who have gotten used to placing imports right above their usage 
 
 If you want to move all imports to the top, you can use the new`--float-to-top` flag in the CLI or `float_to_top=true` option in your config file.
 
-See: [https://timothycrosley.github.io/isort/docs/configuration/options/#float-to-top](https://timothycrosley.github.io/isort/docs/configuration/options/#float-to-top)
+See: [https://pycqa.github.io/isort/docs/configuration/options/#float-to-top](https://pycqa.github.io/isort/docs/configuration/options/#float-to-top)
 
 ## Migrating CLI options
 
@@ -46,7 +46,7 @@ The `-v` (previously for version now for verbose) and `-V` (previously for verbo
 
 The first thing to keep in mind is how isort loads config options has changed in isort 5. It will no longer merge multiple config files, instead you must have 1 isort config per a project.
 If you have multiple configs, they will need to be merged into 1 single one. You can see the priority order of configuration files and the manor in which they are loaded on the
-[config files documentation page](https://timothycrosley.github.io/isort/docs/configuration/config_files/).
+[config files documentation page](https://pycqa.github.io/isort/docs/configuration/config_files/).
 
 ### `not_skip`
 This is the same as the `--dont-skip` CLI option above. In an earlier version isort had a default skip of `__init__.py`. To get around that many projects wanted a way to not skip `__init__.py` or any other files that were automatically skipped in the future by isort. isort no longer has any default skips, so if the value here is `__init__.py` you can simply remove the setting. If it is something else, just make sure you aren't specifying to skip that file somewhere else in your config.
@@ -58,10 +58,10 @@ The option was originally added to allow working around this, and was then turne
 ### `known_standard_library`
 isort settings no longer merge together, instead they override. The old behavior of merging together caused many hard to
 track down errors, but the one place it was very convenient was for adding a few additional standard library modules.
-In isort 5, you can still get this behavior by moving your extra modules from the `known_standard_library` setting to [`extra_standard_library`](https://timothycrosley.github.io/isort/docs/configuration/options/#extra-standard-library).
+In isort 5, you can still get this behavior by moving your extra modules from the `known_standard_library` setting to [`extra_standard_library`](https://pycqa.github.io/isort/docs/configuration/options/#extra-standard-library).
 
 ### module placement changes: `known_third_party`, `known_first_party`, `default_section`, etc...
-isort has completely rewritten its logic for placing modules in 5.0.0 to ensure the same behavior across environments. You can see the details of this change [here](https://github.com/timothycrosley/isort/issues/1147).
+isort has completely rewritten its logic for placing modules in 5.0.0 to ensure the same behavior across environments. You can see the details of this change [here](https://github.com/pycqa/isort/issues/1147).
 The TL;DR of which is that isort has now changed from `default_section=FIRSTPARTY` to `default_section=THIRDPARTY`. If you all already setting the default section to third party, your config is probably in good shape.
 If not, you can either use the old finding approach with `--magic-placement` in the CLI or `old_finders=True` in your config, or preferably, you are able to remove all placement options and isort will determine it correctly.
 If it doesn't, you should be able to just specify your projects modules with `known_first_party` and be done with it.
@@ -77,7 +77,7 @@ If you have a step in your precommit called `seed-isort-config` or similar, it i
 isort now includes an optimized precommit configuration in the repo itself. To use it you can replace any existing isort precommit step with:
 
 ```
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/pycqa/isort
     rev: 5.3.2
     hooks:
       - id: isort

--- a/docs/warning_and_error_codes/W0500.md
+++ b/docs/warning_and_error_codes/W0500.md
@@ -3,7 +3,7 @@
 The W0500 error codes are reserved for warnings related to a major release of the isort project.
 Generally, the existence of any of these will trigger one additional warning listing the upgrade guide.
 
-For the most recent upgrade guide, see: [The 5.0.0 Upgrade Guide.](https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/).
+For the most recent upgrade guide, see: [The 5.0.0 Upgrade Guide.](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/).
 
 ## W0501: Deprecated CLI flags were included that will be ignored.
 

--- a/isort/main.py
+++ b/isort/main.py
@@ -61,7 +61,7 @@ Try one of the following:
     `isort . --check --diff` - Check to see if imports are correctly sorted within this project.
     `isort --help` - In-depth information about isort's available command-line options.
 
-Visit https://timothycrosley.github.io/isort/ for complete information about how to use isort.
+Visit https://pycqa.github.io/isort/ for complete information about how to use isort.
 """
 
 
@@ -146,7 +146,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "interactive behavior."
         ""
         "If you've used isort 4 but are new to isort 5, see the upgrading guide:"
-        "https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/."
+        "https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/."
     )
     inline_args_group = parser.add_mutually_exclusive_group()
     parser.add_argument(
@@ -908,7 +908,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
             )
         warn(
             "W0500: Please see the 5.0.0 Upgrade guide: "
-            "https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/"
+            "https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/"
         )
 
     if wrong_sorted_files:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -329,7 +329,7 @@ class Config(_Config):
                             f"Can't set both {key} and {section_name} in the same config file.\n"
                             f"Default to {section_name} if unsure."
                             "\n\n"
-                            "See: https://timothycrosley.github.io/isort/"
+                            "See: https://pycqa.github.io/isort/"
                             "#custom-sections-and-ordering."
                         )
                     else:
@@ -344,7 +344,7 @@ class Config(_Config):
                             f"`{key}` setting is defined, but {maps_to_section} is not"
                             " included in `sections` config option:"
                             f" {combined_config.get('sections', SECTION_DEFAULTS)}.\n\n"
-                            "See: https://timothycrosley.github.io/isort/"
+                            "See: https://pycqa.github.io/isort/"
                             "#custom-sections-and-ordering."
                         )
             if key.startswith(IMPORT_HEADING_PREFIX):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ description = "A Python utility / library to sort Python imports."
 authors = ["Timothy Crosley <timothy.crosley@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/timothycrosley/isort"
-homepage = "https://timothycrosley.github.io/isort/"
-documentation = "https://timothycrosley.github.io/isort/"
+repository = "https://github.com/pycqa/isort"
+homepage = "https://pycqa.github.io/isort/"
+documentation = "https://pycqa.github.io/isort/"
 keywords = ["Refactor", "Lint", "Imports", "Sort", "Clean"]
 classifiers = [
     "Development Status :: 6 - Mature",
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
 ]
-urls = { Changelog = "https://github.com/timothycrosley/isort/blob/master/CHANGELOG.md" }
+urls = { Changelog = "https://github.com/pycqa/isort/blob/master/CHANGELOG.md" }
 packages = [
     { include = "isort" },
     { include = "tests", format = "sdist" },
@@ -91,7 +91,7 @@ isort = "isort.main:ISortCommand"
 isort = "isort = isort.pylama_isort:Linter"
 
 [tool.portray.mkdocs]
-edit_uri = "https://github.com/timothycrosley/isort/edit/develop/"
+edit_uri = "https://github.com/pycqa/isort/edit/develop/"
 extra_css = ["art/stylesheets/extra.css"]
 
 [tool.portray.mkdocs.theme]

--- a/rtd/index.md
+++ b/rtd/index.md
@@ -1,6 +1,6 @@
 <script>
-window.location.replace("https://timothycrosley.github.io/isort/");
+window.location.replace("https://pycqa.github.io/isort/");
 </script>
 
 The latest isort docs are not on ReadTheDocs. This page contains a javascript redirect to the latest documentation.
-If this redirect doesn't work, please [click here for the latest documentation](https://timothycrosley.github.io/isort/).
+If this redirect doesn't work, please [click here for the latest documentation](https://pycqa.github.io/isort/).

--- a/scripts/build_config_option_docs.py
+++ b/scripts/build_config_option_docs.py
@@ -21,7 +21,8 @@ As a code formatter isort has opinions. However, it also allows you to have your
 isort will disagree but commit to your way of formatting. To enable this, isort exposes a plethora of options to specify
 how you want your imports sorted, organized, and formatted.
 
-Too busy to build your perfect isort configuration? For curated common configurations, see isort's [built-in profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/).
+Too busy to build your perfect isort configuration? For curated common configurations, see isort's [built-in
+profiles](https://pycqa.github.io/isort/docs/configuration/profiles/).
 """
 parser = _build_arg_parser()
 

--- a/scripts/check_acknowledgments.py
+++ b/scripts/check_acknowledgments.py
@@ -10,7 +10,7 @@ import hug
 
 IGNORED_AUTHOR_LOGINS = {"deepsource-autofix[bot]"}
 
-REPO = "timothycrosley/isort"
+REPO = "pycqa/isort"
 GITHUB_API_CONTRIBUTORS = f"https://api.github.com/repos/{REPO}/contributors"
 GITHUB_USER_CONTRIBUTIONS = f"https://github.com/{REPO}/commits?author="
 GITHUB_USER_TYPE = "User"

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -1209,7 +1209,7 @@ def test_force_single_line_imports_and_sort_within_sections() -> None:
     )
 
     # Ensure force_sort_within_sections can work with length sort
-    # See: https://github.com/timothycrosley/isort/issues/1038
+    # See: https://github.com/pycqa/isort/issues/1038
     test_input = """import sympy
 import numpy as np
 import pandas as pd
@@ -3964,7 +3964,7 @@ def test_isort_with_single_character_import() -> None:
     """Tests to ensure isort handles single capatilized single character imports
     as class objects by default
 
-    See Issue #376: https://github.com/timothycrosley/isort/issues/376
+    See Issue #376: https://github.com/pycqa/isort/issues/376
     """
     test_input = "from django.db.models import CASCADE, SET_NULL, Q\n"
     assert isort.code(test_input) == test_input

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -6,7 +6,7 @@ import isort
 
 def test_isort_duplicating_comments_issue_1264():
     """Ensure isort doesn't duplicate comments when force_sort_within_sections is set to `True`
-    as was the case in issue #1264: https://github.com/timothycrosley/isort/issues/1264
+    as was the case in issue #1264: https://github.com/pycqa/isort/issues/1264
     """
     assert (
         isort.code(
@@ -42,7 +42,7 @@ def test_moving_comments_issue_726():
 
 def test_blank_lined_removed_issue_1275():
     """Ensure isort doesn't accidentally remove blank lines after doc strings and before imports.
-    See: https://github.com/timothycrosley/isort/issues/1275
+    See: https://github.com/pycqa/isort/issues/1275
     """
     assert (
         isort.code(
@@ -86,7 +86,7 @@ from b import thing
 
 def test_blank_lined_removed_issue_1283():
     """Ensure isort doesn't accidentally remove blank lines after __version__ identifiers.
-    See: https://github.com/timothycrosley/isort/issues/1283
+    See: https://github.com/pycqa/isort/issues/1283
     """
     test_input = """__version__ = "0.58.1"
 
@@ -97,7 +97,7 @@ from starlette import status
 
 def test_extra_blank_line_added_nested_imports_issue_1290():
     """Ensure isort doesn't added unecessary blank lines above nested imports.
-    See: https://github.com/timothycrosley/isort/issues/1290
+    See: https://github.com/pycqa/isort/issues/1290
     """
     test_input = '''from typing import TYPE_CHECKING
 
@@ -129,7 +129,7 @@ def func():
 
 def test_add_imports_shouldnt_make_isort_unusable_issue_1297():
     """Test to ensure add imports doesn't cause any unexpected behaviour when combined with check
-    See: https://github.com/timothycrosley/isort/issues/1297
+    See: https://github.com/pycqa/isort/issues/1297
     """
     assert isort.check_code(
         """from __future__ import unicode_literals
@@ -142,7 +142,7 @@ from os import path
 
 def test_no_extra_lines_for_imports_in_functions_issue_1277():
     """Test to ensure isort doesn't introduce extra blank lines for imports within function.
-    See: https://github.com/timothycrosley/isort/issues/1277
+    See: https://github.com/pycqa/isort/issues/1277
     """
     test_input = """
 def main():
@@ -160,7 +160,7 @@ def main():
 
 def test_no_extra_blank_lines_in_methods_issue_1293():
     """Test to ensure isort isn't introducing extra lines in methods that contain imports
-    See: https://github.com/timothycrosley/isort/issues/1293
+    See: https://github.com/pycqa/isort/issues/1293
     """
     test_input = """
 
@@ -178,7 +178,7 @@ class Something(object):
 
 def test_force_single_line_shouldnt_remove_preceding_comment_lines_issue_1296():
     """Tests to ensure force_single_line setting doesn't result in lost comments.
-    See: https://github.com/timothycrosley/isort/issues/1296
+    See: https://github.com/pycqa/isort/issues/1296
     """
     test_input = """
 # A comment
@@ -195,7 +195,7 @@ def test_ensure_new_line_before_comments_mixed_with_ensure_newline_before_commen
     """Tests to ensure that the black profile can be used in conjunction with
     force_sort_within_sections.
 
-    See: https://github.com/timothycrosley/isort/issues/1295
+    See: https://github.com/pycqa/isort/issues/1295
     """
     test_input = """
 from openzwave.group import ZWaveGroup
@@ -210,7 +210,7 @@ from openzwave.option import ZWaveOption
 
 def test_trailing_comma_doesnt_introduce_broken_code_with_comment_and_wrap_issue_1302():
     """Tests to assert the combination of include_trailing_comma and a wrapped line doesnt break.
-    See: https://github.com/timothycrosley/isort/issues/1302.
+    See: https://github.com/pycqa/isort/issues/1302.
     """
     assert (
         isort.code(
@@ -229,14 +229,14 @@ from somewhere import \\
 
 def test_ensure_sre_parse_is_identified_as_stdlib_issue_1304():
     """Ensure sre_parse is idenified as STDLIB.
-    See: https://github.com/timothycrosley/isort/issues/1304.
+    See: https://github.com/pycqa/isort/issues/1304.
     """
     assert isort.place_module("sre_parse") == isort.place_module("sre") == isort.settings.STDLIB
 
 
 def test_add_imports_shouldnt_move_lower_comments_issue_1300():
     """Ensure add_imports doesn't move comments immediately below imports.
-    See:: https://github.com/timothycrosley/isort/issues/1300.
+    See:: https://github.com/pycqa/isort/issues/1300.
     """
     test_input = """from __future__ import unicode_literals
 
@@ -250,7 +250,7 @@ ANSWER = 42
 
 def test_windows_newline_issue_1277():
     """Test to ensure windows new lines are correctly handled within indented scopes.
-    See: https://github.com/timothycrosley/isort/issues/1277
+    See: https://github.com/pycqa/isort/issues/1277
     """
     assert (
         isort.code("\ndef main():\r\n    import time\r\n\n    import sys\r\n")
@@ -260,7 +260,7 @@ def test_windows_newline_issue_1277():
 
 def test_windows_newline_issue_1278():
     """Test to ensure windows new lines are correctly handled within indented scopes.
-    See: https://github.com/timothycrosley/isort/issues/1278
+    See: https://github.com/pycqa/isort/issues/1278
     """
     assert isort.check_code(
         "\ntry:\r\n    import datadog_agent\r\n\r\n    "
@@ -271,7 +271,7 @@ def test_windows_newline_issue_1278():
 
 def test_check_never_passes_with_indented_headings_issue_1301():
     """Test to ensure that test can pass even when there are indented headings.
-    See: https://github.com/timothycrosley/isort/issues/1301
+    See: https://github.com/pycqa/isort/issues/1301
     """
     assert isort.check_code(
         """
@@ -289,7 +289,7 @@ except ImportError:
 def test_isort_shouldnt_fail_on_long_from_with_dot_issue_1190():
     """Test to ensure that isort will correctly handle formatting a long from import that contains
     a dot.
-    See: https://github.com/timothycrosley/isort/issues/1190
+    See: https://github.com/pycqa/isort/issues/1190
     """
     assert (
         isort.code(
@@ -315,7 +315,7 @@ from this_is_a_very_long_import_statement.that_will_occur_across_two_lines"""
 
 def test_isort_shouldnt_add_extra_new_line_when_fass_and_n_issue_1315():
     """Test to ensure isort doesnt add a second extra new line when combining --fss and -n options.
-    See: https://github.com/timothycrosley/isort/issues/1315
+    See: https://github.com/pycqa/isort/issues/1315
     """
     assert isort.check_code(
         """import sys
@@ -351,7 +351,7 @@ def test_isort_doesnt_rewrite_import_with_dot_to_from_import_issue_1280():
     """Test to ensure isort doesn't rewrite imports in the from of import y.x into from y import x.
     This is because they are not technically fully equivalent to eachother and can introduce broken
     behaviour.
-    See: https://github.com/timothycrosley/isort/issues/1280
+    See: https://github.com/pycqa/isort/issues/1280
     """
     assert isort.check_code(
         """
@@ -366,7 +366,7 @@ def test_isort_doesnt_rewrite_import_with_dot_to_from_import_issue_1280():
 
 def test_isort_shouldnt_introduce_extra_lines_with_fass_issue_1322():
     """Tests to ensure isort doesn't introduce extra lines when used with fass option.
-    See: https://github.com/timothycrosley/isort/issues/1322
+    See: https://github.com/pycqa/isort/issues/1322
     """
     assert (
         isort.code(
@@ -393,7 +393,7 @@ import quux
 def test_comments_should_cause_wrapping_on_long_lines_black_mode_issue_1219():
     """Tests to ensure if isort encounters a single import line which is made too long with a comment
     it is wrapped when using black profile.
-    See: https://github.com/timothycrosley/isort/issues/1219
+    See: https://github.com/pycqa/isort/issues/1219
     """
     assert isort.check_code(
         """
@@ -409,7 +409,7 @@ from many_stop_words import (
 def test_comment_blocks_should_stay_associated_without_extra_lines_issue_1156():
     """Tests to ensure isort doesn't add an extra line when there are large import blocks
     or otherwise warp the intent.
-    See: https://github.com/timothycrosley/isort/issues/1156
+    See: https://github.com/pycqa/isort/issues/1156
     """
     assert (
         isort.code(
@@ -434,7 +434,7 @@ from ast import excepthandler
 def test_comment_shouldnt_be_duplicated_with_fass_enabled_issue_1329():
     """Tests to ensure isort doesn't duplicate comments when imports occur with comment on top,
     immediately after large comment blocks.
-    See: https://github.com/timothycrosley/isort/pull/1329/files.
+    See: https://github.com/pycqa/isort/pull/1329/files.
     """
     assert isort.check_code(
         """'''
@@ -469,7 +469,7 @@ def function():
 
 def test_isort_skipped_nested_imports_issue_1339():
     """Ensure `isort:skip are honored in nested imports.
-    See: https://github.com/timothycrosley/isort/issues/1339.
+    See: https://github.com/pycqa/isort/issues/1339.
     """
     assert isort.check_code(
         """
@@ -484,7 +484,7 @@ def test_isort_skipped_nested_imports_issue_1339():
 
 def test_windows_diff_too_large_misrepresentative_issue_1348(test_path):
     """Ensure isort handles windows files correctly when it come to producing a diff with --diff.
-    See: https://github.com/timothycrosley/isort/issues/1348
+    See: https://github.com/pycqa/isort/issues/1348
     """
     diff_output = StringIO()
     isort.file(test_path / "example_crlf_file.py", show_diff=diff_output)
@@ -496,7 +496,7 @@ def test_windows_diff_too_large_misrepresentative_issue_1348(test_path):
 
 def test_combine_as_does_not_lose_comments_issue_1321():
     """Test to ensure isort doesn't lose comments when --combine-as is used.
-    See: https://github.com/timothycrosley/isort/issues/1321
+    See: https://github.com/pycqa/isort/issues/1321
     """
     test_input = """
 from foo import *  # noqa
@@ -524,7 +524,7 @@ from foo import bar as quux, x as a  # other; noqa
 
 def test_combine_as_does_not_lose_comments_issue_1381():
     """Test to ensure isort doesn't lose comments when --combine-as is used.
-    See: https://github.com/timothycrosley/isort/issues/1381
+    See: https://github.com/pycqa/isort/issues/1381
     """
     test_input = """
 from smtplib import SMTPConnectError, SMTPNotSupportedError  # important comment
@@ -539,7 +539,7 @@ from appsettings import AppSettings, ObjectSetting, StringSetting  # type: ignor
 
 def test_incorrect_grouping_when_comments_issue_1396():
     """Test to ensure isort groups import correct independent of the comments present.
-    See: https://github.com/timothycrosley/isort/issues/1396
+    See: https://github.com/pycqa/isort/issues/1396
     """
     assert (
         isort.code(
@@ -601,7 +601,7 @@ from apps.profiler.models import Project
 
 def test_reverse_relative_combined_with_force_sort_within_sections_issue_1395():
     """Test to ensure reverse relative combines well with other common isort settings.
-    See: https://github.com/timothycrosley/isort/issues/1395.
+    See: https://github.com/pycqa/isort/issues/1395.
     """
     assert isort.check_code(
         """from .fileA import a_var

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -13,7 +13,7 @@ from isort import Config, exceptions
 def test_semicolon_ignored_for_dynamic_lines_after_import_issue_1178():
     """Test to ensure even if a semicolon is in the decorator in the line following an import
     the correct line spacing detrmination will be made.
-    See: https://github.com/timothycrosley/isort/issues/1178.
+    See: https://github.com/pycqa/isort/issues/1178.
     """
     assert isort.check_code(
         """
@@ -29,7 +29,7 @@ def test_thing(): pass
 
 def test_isort_automatically_removes_duplicate_aliases_issue_1193():
     """Test to ensure isort can automatically remove duplicate aliases.
-    See: https://github.com/timothycrosley/isort/issues/1281
+    See: https://github.com/pycqa/isort/issues/1281
     """
     assert isort.check_code("from urllib import parse as parse\n", show_diff=True)
     assert (
@@ -42,7 +42,7 @@ def test_isort_automatically_removes_duplicate_aliases_issue_1193():
 
 def test_isort_enables_floating_imports_to_top_of_module_issue_1228():
     """Test to ensure isort will allow floating all non-indented imports to the top of a file.
-    See: https://github.com/timothycrosley/isort/issues/1228.
+    See: https://github.com/pycqa/isort/issues/1228.
     """
     assert (
         isort.code(
@@ -159,7 +159,7 @@ def my_function_2():
 
 def test_isort_provides_official_api_for_diff_output_issue_1335():
     """Test to ensure isort API for diff capturing allows capturing diff without sys.stdout.
-    See: https://github.com/timothycrosley/isort/issues/1335.
+    See: https://github.com/pycqa/isort/issues/1335.
     """
     diff_output = StringIO()
     isort.code("import b\nimport a\n", show_diff=diff_output)
@@ -169,7 +169,7 @@ def test_isort_provides_official_api_for_diff_output_issue_1335():
 
 def test_isort_warns_when_known_sections_dont_match_issue_1331():
     """Test to ensure that isort warns if there is a mismatch between sections and known_sections.
-    See: https://github.com/timothycrosley/isort/issues/1331.
+    See: https://github.com/pycqa/isort/issues/1331.
     """
     assert (
         isort.place_module(
@@ -203,7 +203,7 @@ def test_isort_warns_when_known_sections_dont_match_issue_1331():
 
 def test_isort_supports_append_only_imports_issue_727():
     """Test to ensure isort provides a way to only add imports as an append.
-    See: https://github.com/timothycrosley/isort/issues/727.
+    See: https://github.com/pycqa/isort/issues/727.
     """
     assert isort.code("", add_imports=["from __future__ import absolute_imports"]) == ""
     assert (
@@ -217,7 +217,7 @@ import os
 
 def test_isort_supports_shared_profiles_issue_970():
     """Test to ensure isort provides a way to use shared profiles.
-    See: https://github.com/timothycrosley/isort/issues/970.
+    See: https://github.com/pycqa/isort/issues/970.
     """
     assert isort.code("import a", profile="example") == "import a\n"  # shared profile
     assert isort.code("import a", profile="black") == "import a\n"  # bundled profile
@@ -227,7 +227,7 @@ def test_isort_supports_shared_profiles_issue_970():
 
 def test_isort_supports_formatting_plugins_issue_1353():
     """Test to ensure isort provides a way to create and share formatting plugins.
-    See: https://github.com/timothycrosley/isort/issues/1353.
+    See: https://github.com/pycqa/isort/issues/1353.
     """
     assert isort.code("import a", formatter="example") == "import a\n"  # formatting plugin
     with pytest.raises(exceptions.FormattingPluginDoesNotExist):
@@ -236,7 +236,7 @@ def test_isort_supports_formatting_plugins_issue_1353():
 
 def test_treating_comments_as_code_issue_1357():
     """Test to ensure isort provides a way to treat comments as code.
-    See: https://github.com/timothycrosley/isort/issues/1357
+    See: https://github.com/pycqa/isort/issues/1357
     """
     assert (
         isort.code(
@@ -488,7 +488,7 @@ y = {"b": "c", "z": "z"}"""
 
 def test_isort_allows_setting_import_types_issue_1181():
     """Test to ensure isort provides a way to set the type of imports.
-    See: https://github.com/timothycrosley/isort/issues/1181
+    See: https://github.com/pycqa/isort/issues/1181
     """
     assert isort.code("from x import AA, Big, variable") == "from x import AA, Big, variable\n"
     assert (
@@ -512,7 +512,7 @@ def test_isort_allows_setting_import_types_issue_1181():
 
 def test_isort_enables_deduping_section_headers_issue_953():
     """isort should provide a way to only have identical import headings show up once.
-    See: https://github.com/timothycrosley/isort/issues/953
+    See: https://github.com/pycqa/isort/issues/953
     """
     isort_code = partial(
         isort.code,


### PR DESCRIPTION
As a result of moving the repo to PyCQA some links were broken.
Some of them were properly redirected, so it is easier to just mechanically change all the references.

Left the following badge links in `README.md` still with old references as they need some setup in the services they are linking to:

- Maintainability badge - codeclimate
- Gitter badge
- DeepSource badge

