### PR TITLE
Fix documentation for skip_file action comment

### DIFF
--- a/docs/configuration/action_comments.md
+++ b/docs/configuration/action_comments.md
@@ -3,7 +3,7 @@
 The most basic way to configure the flow of isort within a single file is action comments. These comments are picked up and interpreted by the isort parser during parsing.
 
 
-## isort: skip-file
+## isort: skip_file
 
 Tells isort to skip the entire file.
 
@@ -11,7 +11,7 @@ Example:
 
 ```python
 # !/bin/python3
-# isort: skip-file
+# isort: skip_file
 import os
 import sys
 


### PR DESCRIPTION
The [documentation](https://pycqa.github.io/isort/docs/configuration/action_comments/) currently lists this as `skip-file`, whereas the default in settings.py has an underscore: https://github.com/PyCQA/isort/blob/cf44d6720f27973cdb54a48bbe8b91bae9055821/isort/settings.py#L31-L34

Am assuming people might be relying on the actual implementation, so changing the documentation is the most reasonable course (absent knowledge of intention)

This had me confused for a bit!