### PR TITLE
Issue/1380/dont combine as into star

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -258,11 +258,12 @@ def _with_from_imports(
                         from_imports[idx : (idx + 1)] = as_imports.pop(from_import)
 
         only_show_as_imports = False
+        comments = parsed.categorized_comments["from"].pop(module, ())
+        above_comments = parsed.categorized_comments["above"]["from"].pop(module, None)
         while from_imports:
-            comments = parsed.categorized_comments["from"].pop(module, ())
-            above_comments = parsed.categorized_comments["above"]["from"].pop(module, None)
             if above_comments:
                 output.extend(above_comments)
+                above_comments = None
 
             if "*" in from_imports and config.combine_star:
                 import_statement = wrap.line(

--- a/isort/output.py
+++ b/isort/output.py
@@ -264,11 +264,6 @@ def _with_from_imports(
                 output.extend(above_comments)
 
             if "*" in from_imports and config.combine_star:
-                if config.combine_as_imports:
-                    comments = list(comments or ())
-                    comments += parsed.categorized_comments["from"].pop(
-                        f"{module}.__combined_as__", []
-                    )
                 import_statement = wrap.line(
                     with_comments(
                         comments,
@@ -279,7 +274,9 @@ def _with_from_imports(
                     parsed.line_separator,
                     config,
                 )
-                from_imports = []
+                from_imports = [
+                    from_import for from_import in from_imports if from_import in as_imports
+                ]
             elif config.force_single_line and module not in config.single_line_exclusions:
                 import_statement = ""
                 while from_imports:

--- a/isort/output.py
+++ b/isort/output.py
@@ -257,6 +257,7 @@ def _with_from_imports(
                     else:
                         from_imports[idx : (idx + 1)] = as_imports.pop(from_import)
 
+        only_show_as_imports = False
         while from_imports:
             comments = parsed.categorized_comments["from"].pop(module, ())
             above_comments = parsed.categorized_comments["above"]["from"].pop(module, None)
@@ -277,6 +278,7 @@ def _with_from_imports(
                 from_imports = [
                     from_import for from_import in from_imports if from_import in as_imports
                 ]
+                only_show_as_imports = True
             elif config.force_single_line and module not in config.single_line_exclusions:
                 import_statement = ""
                 while from_imports:
@@ -295,7 +297,10 @@ def _with_from_imports(
                             f"{comments and ';' or config.comment_prefix} " f"{comment}"
                         )
                     if from_import in as_imports:
-                        if parsed.imports[section]["from"][module][from_import]:
+                        if (
+                            parsed.imports[section]["from"][module][from_import]
+                            and not only_show_as_imports
+                        ):
                             output.append(
                                 wrap.line(single_import_line, parsed.line_separator, config)
                             )
@@ -321,7 +326,10 @@ def _with_from_imports(
                     from_comments = parsed.categorized_comments["straight"].get(
                         f"{module}.{from_import}"
                     )
-                    if parsed.imports[section]["from"][module][from_import]:
+                    if (
+                        parsed.imports[section]["from"][module][from_import]
+                        and not only_show_as_imports
+                    ):
                         output.append(
                             wrap.line(
                                 with_comments(

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -503,7 +503,7 @@ class Config(_Config):
             config_key = f"{KNOWN_PREFIX}{known_placement}"
             known_modules = getattr(self, config_key, self.known_other.get(known_placement, ()))
             extra_modules = getattr(self, f"extra_{known_placement}", ())
-            all_modules = set(known_modules).union(extra_modules)
+            all_modules = set(extra_modules).union(known_modules)
             known_patterns = [
                 pattern
                 for known_pattern in all_modules

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -3425,6 +3425,13 @@ def test_all_imports_from_single_module() -> None:
         "from a import i as j\n"
         "from a import w, x, y, z\n"
     )
+    test_input = (
+        "import a\n"
+        "from a import *\n"
+        "from a import z, x, y\n"
+        "from a import b\n"
+        "from a import w\n"
+    )
     test_output = isort.code(
         code=test_input,
         combine_star=True,
@@ -3433,6 +3440,13 @@ def test_all_imports_from_single_module() -> None:
         no_inline_sort=False,
     )
     assert test_output == "import a\nfrom a import *\n"
+    test_input += """
+from a import b as c
+from a import b as d
+from a import e as f
+from a import g as h
+from a import i as j
+"""
     test_output = isort.code(
         code=test_input,
         combine_star=False,
@@ -3466,6 +3480,17 @@ def test_all_imports_from_single_module() -> None:
         "from a import y\n"
         "from a import z\n"
     )
+    test_input = (
+        "import a\n"
+        "from a import *\n"
+        "from a import b\n"
+        "from a import b as d\n"
+        "from a import b as c\n"
+        "from a import z, x, y, w\n"
+        "from a import i as j\n"
+        "from a import g as h\n"
+        "from a import e as f\n"
+    )
     test_output = isort.code(
         code=test_input,
         combine_star=False,
@@ -3484,6 +3509,13 @@ def test_all_imports_from_single_module() -> None:
         "from a import g as h\n"
         "from a import e as f\n"
     )
+    test_input = (
+        "import a\n"
+        "from a import *\n"
+        "from a import z, x, y\n"
+        "from a import b\n"
+        "from a import w\n"
+    )
     test_output = isort.code(
         code=test_input,
         combine_star=True,
@@ -3519,15 +3551,21 @@ def test_all_imports_from_single_module() -> None:
         "import a\n"
         "from a import *\n"
         "from a import b\n"
-        "from a import b as c\n"
-        "from a import b as d\n"
-        "from a import e as f\n"
-        "from a import g as h\n"
-        "from a import i as j\n"
         "from a import w\n"
         "from a import x\n"
         "from a import y\n"
         "from a import z\n"
+    )
+    test_input = (
+        "import a\n"
+        "from a import *\n"
+        "from a import b\n"
+        "from a import b as d\n"
+        "from a import b as c\n"
+        "from a import z, x, y, w\n"
+        "from a import i as j\n"
+        "from a import g as h\n"
+        "from a import e as f\n"
     )
     test_output = isort.code(
         code=test_input,
@@ -3561,6 +3599,13 @@ def test_all_imports_from_single_module() -> None:
         "from a import x\n"
         "from a import y\n"
         "from a import z\n"
+    )
+    test_input = (
+        "import a\n"
+        "from a import *\n"
+        "from a import z, x, y\n"
+        "from a import b\n"
+        "from a import w\n"
     )
     test_output = isort.code(
         code=test_input,

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -543,3 +543,25 @@ from . import something
 """
     )
     assert isort_code("import os") == "import os\n"
+
+
+def test_isort_doesnt_remove_as_imports_when_combine_star_issue_1380():
+    """Test to ensure isort will not remove as imports along side other imports
+    when requested to combine star imports together.
+    See: https://github.com/PyCQA/isort/issues/1380
+    """
+    assert (
+        isort.code(
+            """
+from a import a
+from a import *
+from a import b as y
+from a import c
+""",
+            combine_star=True,
+        )
+        == """
+from a import *
+from a import b as y
+"""
+    )

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -550,15 +550,18 @@ def test_isort_doesnt_remove_as_imports_when_combine_star_issue_1380():
     when requested to combine star imports together.
     See: https://github.com/PyCQA/isort/issues/1380
     """
-    assert (
-        isort.code(
-            """
+    test_input = """
 from a import a
 from a import *
+from a import b
 from a import b as y
 from a import c
-""",
-            combine_star=True,
+"""
+    assert (
+        isort.code(test_input, combine_star=True,)
+        == isort.code(test_input, combine_star=True, force_single_line=True)
+        == isort.code(
+            test_input, combine_star=True, force_single_line=True, combine_as_imports=True,
         )
         == """
 from a import *


### PR DESCRIPTION
Resolves #1380:

Updates isort to not remove as import, even when combine_star is set:

```
from os import *
from os import path
from os import path as ospath
```

Now outputs:

```
from os import *
from os import path as ospath
```

Instead of:

```
from os import *
```