### PR TITLE
Issue/1407/custom known group not always working

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -347,7 +347,6 @@ class Config(_Config):
                             "See: https://pycqa.github.io/isort/"
                             "#custom-sections-and-ordering."
                         )
-
             if key.startswith(IMPORT_HEADING_PREFIX):
                 import_headings[key[len(IMPORT_HEADING_PREFIX) :].lower()] = str(value)
 
@@ -505,7 +504,7 @@ class Config(_Config):
             config_key = f"{KNOWN_PREFIX}{known_placement}"
             known_modules = getattr(self, config_key, self.known_other.get(known_placement, ()))
             extra_modules = getattr(self, f"extra_{known_placement}", ())
-            all_modules = set(known_modules).union(extra_modules)
+            all_modules = set(extra_modules).union(known_modules)
             known_patterns = [
                 pattern
                 for known_pattern in all_modules

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -347,6 +347,7 @@ class Config(_Config):
                             "See: https://pycqa.github.io/isort/"
                             "#custom-sections-and-ordering."
                         )
+
             if key.startswith(IMPORT_HEADING_PREFIX):
                 import_headings[key[len(IMPORT_HEADING_PREFIX) :].lower()] = str(value)
 
@@ -498,12 +499,13 @@ class Config(_Config):
             return self._known_patterns
 
         self._known_patterns = []
-        for placement in reversed(self.sections):
+        pattern_sections = [STDLIB] + [section for section in self.sections if section != STDLIB]
+        for placement in reversed(pattern_sections):
             known_placement = KNOWN_SECTION_MAPPING.get(placement, placement).lower()
             config_key = f"{KNOWN_PREFIX}{known_placement}"
             known_modules = getattr(self, config_key, self.known_other.get(known_placement, ()))
             extra_modules = getattr(self, f"extra_{known_placement}", ())
-            all_modules = set(extra_modules).union(known_modules)
+            all_modules = set(known_modules).union(extra_modules)
             known_patterns = [
                 pattern
                 for known_pattern in all_modules

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -568,3 +568,22 @@ from a import *
 from a import b as y
 """
     )
+
+
+def test_isort_support_custom_groups_above_stdlib_that_contain_stdlib_modules_issue_1407():
+    """Test to ensure it is possible to declare custom groups above standard library that include
+    modules from the standard library.
+    See: https://github.com/PyCQA/isort/issues/1407
+    """
+    assert isort.check_code(
+        """
+from __future__ import annotations
+from typing import *
+
+from pathlib import Path
+""",
+        known_typing=["typing"],
+        sections=["FUTURE", "TYPING", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"],
+        no_lines_before=["TYPING"],
+        show_diff=True,
+    )


### PR DESCRIPTION
Fixes #1407:

Explicitly defined custom `known_` definitions should always take precedence over the defaults. Since `known_standard_library` is the only special case with a default, it should always have the lowest priority.