### PR TITLE
Fix #1420: Ensure isort doesn't include new imports in comparison

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -215,9 +215,7 @@ def process(
                         if not import_section:
                             output_stream.write(line)
                             line = ""
-                        import_section += line_separator.join(add_imports) + line_separator
                         contains_imports = True
-                        add_imports = []
                     else:
                         not_imports = True
                 elif (

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -617,3 +617,18 @@ from ..fileB import b_var
         lines_after_imports=2,
         no_lines_before="LOCALFOLDER",
     )
+
+
+def test_isort_should_be_able_to_add_independent_of_doc_string_placement_issue_1420():
+    """isort should be able to know when an import requested to be added is sucesfully added,
+    independent of where the top doc string is located.
+    See: https://github.com/PyCQA/isort/issues/1420
+    """
+    assert isort.check_code(
+        '''"""module docstring"""
+
+import os
+''',
+        show_diff=True,
+        add_imports=["os"],
+    )


### PR DESCRIPTION
Fixes #1420: isort in the case of a line between imports and doc string was incorrectly including the new imports in the comparison,  making it believe the code was always being changed.