### PR TITLE
Get rid of warnings displayed when running pytest.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,10 @@ strict_optional = False
 
 [tool:pytest]
 testpaths = tests
+filterwarnings =
+    ignore::DeprecationWarning:distlib
+    ignore::DeprecationWarning:requirementslib
+    ignore::hypothesis.errors.NonInteractiveExampleWarning:hypothesis
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
@timothycrosley I guess you get warnings as well when running pytest?

I don't like scrolling back through them to get to the diffs etc., so I used these filters locally for a while.

Maybe worth adding to the repo?
