### PR TITLE
Make black target Python version 3.6

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,8 +3,7 @@ set -euxo pipefail
 
 poetry run cruft check
 poetry run mypy --ignore-missing-imports isort/
-poetry run black --check isort/ tests/
-poetry run black --check example_isort_formatting_plugin/
+poetry run black --target-version py36 --check .
 poetry run isort --profile hug --check --diff isort/ tests/
 poetry run isort --profile hug --check --diff example_isort_formatting_plugin/
 poetry run flake8 isort/ tests/


### PR DESCRIPTION
Now aligns with isort lowest supported version as well as other tools
like mypy.