### PR TITLE
Remove unused optional dependency tomlkit

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1656,11 +1656,12 @@ testing = ["jaraco.itertools", "func-timeout"]
 
 [extras]
 colors = ["colorama"]
-pipfile_deprecated_finder = ["pipreqs", "tomlkit", "requirementslib"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
 
 [metadata]
-content-hash = "c366831acb4de815d36de7d6072c341ae3a1a1cca409490b5c81fe1159977597"
+content-hash = "b0253934829c50ca3694ad1b04e96761dd3122140ccf34b251e8b1b91dea4ca6"
+lock-version = "1.0"
 python-versions = "^3.6"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,11 @@ packages = [
 python = "^3.6"
 pipreqs = {version = "*", optional = true}
 requirementslib = {version = "*", optional = true}
-tomlkit = {version = ">=0.5.3", optional = true}
 pip-api = {version = "*", optional = true}
 colorama = {version = "^0.4.3", optional = true}
 
 [tool.poetry.extras]
-pipfile_deprecated_finder = ["pipreqs", "tomlkit", "requirementslib", "pip-shims<=0.3.4"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib", "pip-shims<=0.3.4"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama"]
 
@@ -69,7 +68,6 @@ portray = { version = "^1.3.0" }
 pipfile = "^0.0.2"
 requirementslib = "^1.5"
 pipreqs = "^0.4.9"
-tomlkit = ">=0.5.3"
 pip_api = "^0.0.12"
 numpy = "^1.16.0"
 pylama = "^7.7"


### PR DESCRIPTION
Never imported directly by isort, so don't list it as a dependency. When
it is necessary as a transient dependency, that is handled by isort's
direct dependencies.