### PR TITLE
Simplify flake8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,7 @@ testpaths = tests
 [flake8]
 max-line-length = 100
 # Ignore non PEP 8 compliant rules as suggested by black
-ignore =
-    W503  # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-breaks--binary-operators
+extend-ignore =
     E203  # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#slices
 exclude = _vendored
 per-file-ignores =


### PR DESCRIPTION
W503 is ignored by default. Use extend ignore to modify the defaults
rather than override them.