### PR TITLE
Resovle #1434 add backslash-grid mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ notified.
 
 You will notice above the \"multi\_line\_output\" setting. This setting
 defines how from imports wrap when they extend past the line\_length
-limit and has 6 possible settings:
+limit and has 12 possible settings:
 
 **0 - Grid**
 
@@ -285,7 +285,18 @@ from third_party import (
     lib4, lib5, lib6)
 ```
 
-Note: to change the how constant indents appear - simply change the
+**11 - Backslash Grid**
+
+Same as Mode 0 - _Grid_ but uses backslashes instead of parentheses to group imports.
+
+```python
+from third_party import lib1, lib2, lib3, \
+                        lib4, lib5
+```
+
+## Indentation
+
+To change the how constant indents appear - simply change the
 indent property with the following accepted formats:
 
 -   Number of spaces you would like. For example: 4 would cause standard

--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -60,11 +60,11 @@ def grid(**interface):
             len(next_statement.split(interface["line_separator"])[-1]) + 1
             > interface["line_length"]
         ):
-            lines = [f"{white_space}{next_import.split(' ')[0]}"]
+            lines = [f"{interface['white_space']}{next_import.split(' ')[0]}"]
             for part in next_import.split(" ")[1:]:
                 new_line = f"{lines[-1]} {part}"
                 if len(new_line) + 1 > interface["line_length"]:
-                    lines.append(f"{white_space}{part}")
+                    lines.append(f"{interface['white_space']}{part}")
                 else:
                     lines[-1] = new_line
             next_import = interface["line_separator"].join(lines)

--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -60,11 +60,11 @@ def grid(**interface):
             len(next_statement.split(interface["line_separator"])[-1]) + 1
             > interface["line_length"]
         ):
-            lines = [f"{interface['white_space']}{next_import.split(' ')[0]}"]
+            lines = [f"{white_space}{next_import.split(' ')[0]}"]
             for part in next_import.split(" ")[1:]:
                 new_line = f"{lines[-1]} {part}"
                 if len(new_line) + 1 > interface["line_length"]:
-                    lines.append(f"{interface['white_space']}{part}")
+                    lines.append(f"{white_space}{part}")
                 else:
                     lines[-1] = new_line
             next_import = interface["line_separator"].join(lines)
@@ -304,6 +304,12 @@ def vertical_prefix_from_module_import(**interface):
 @_wrap_mode
 def hanging_indent_with_parentheses(**interface):
     return _hanging_indent_common(use_parentheses=True, **interface)
+
+
+@_wrap_mode
+def backslash_grid(**interface):
+    interface["indent"] = interface["white_space"][:-1]
+    return _hanging_indent_common(use_parentheses=False, **interface)
 
 
 WrapModes = enum.Enum(  # type: ignore

--- a/tests/unit/test_wrap_modes.py
+++ b/tests/unit/test_wrap_modes.py
@@ -1,5 +1,6 @@
 from hypothesis_auto import auto_pytest_magic
 
+import isort
 from isort import wrap_modes
 
 auto_pytest_magic(wrap_modes.grid, auto_allow_exceptions_=(ValueError,))
@@ -21,6 +22,7 @@ auto_pytest_magic(
     imports=["one", "two"],
 )
 auto_pytest_magic(wrap_modes.hanging_indent_with_parentheses, auto_allow_exceptions_=(ValueError,))
+auto_pytest_magic(wrap_modes.backslash_grid, auto_allow_exceptions_=(ValueError,))
 
 
 def test_wrap_mode_interface():
@@ -65,3 +67,22 @@ def test_auto_saved():
         )
         == '*\x12\x07\U0009e994🁣"\U000ae787\x0e \x00\U0001ae99\U0005c3e7\U0004d08e \x1e  '
     )
+
+
+def test_backslash_grid():
+    """Tests the backslash_grid grid wrap mode, ensuring it matches formatting expectations.
+    See: https://github.com/PyCQA/isort/issues/1434
+    """
+    assert isort.code("""
+from kopf.engines import loggers, posting
+from kopf.reactor import causation, daemons, effects, handling, lifecycles, registries
+from kopf.storage import finalizers, states
+from kopf.structs import (bodies, configuration, containers, diffs,
+                          handlers as handlers_, patches, resources)
+""", multi_line_output=11, line_length=88, combine_as_imports=True) == """
+from kopf.engines import loggers, posting
+from kopf.reactor import causation, daemons, effects, handling, lifecycles, registries
+from kopf.storage import finalizers, states
+from kopf.structs import bodies, configuration, containers, diffs, \\
+                         handlers as handlers_, patches, resources
+"""

--- a/tests/unit/test_wrap_modes.py
+++ b/tests/unit/test_wrap_modes.py
@@ -73,16 +73,24 @@ def test_backslash_grid():
     """Tests the backslash_grid grid wrap mode, ensuring it matches formatting expectations.
     See: https://github.com/PyCQA/isort/issues/1434
     """
-    assert isort.code("""
+    assert (
+        isort.code(
+            """
 from kopf.engines import loggers, posting
 from kopf.reactor import causation, daemons, effects, handling, lifecycles, registries
 from kopf.storage import finalizers, states
 from kopf.structs import (bodies, configuration, containers, diffs,
                           handlers as handlers_, patches, resources)
-""", multi_line_output=11, line_length=88, combine_as_imports=True) == """
+""",
+            multi_line_output=11,
+            line_length=88,
+            combine_as_imports=True,
+        )
+        == """
 from kopf.engines import loggers, posting
 from kopf.reactor import causation, daemons, effects, handling, lifecycles, registries
 from kopf.storage import finalizers, states
 from kopf.structs import bodies, configuration, containers, diffs, \\
                          handlers as handlers_, patches, resources
 """
+    )


### PR DESCRIPTION
Implements #1434: Adds an additional wrap mode for grid that doesn't use parentheses. 