### PR TITLE
Issue/1447/stdin pipe exception deprecated arguments

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -823,11 +823,10 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
         print(json.dumps(config.__dict__, indent=4, separators=(",", ": "), default=_preconvert))
         return
     elif file_names == ["-"]:
-        arguments.setdefault("settings_path", os.getcwd())
         api.sort_stream(
             input_stream=sys.stdin if stdin is None else stdin,
             output_stream=sys.stdout,
-            **arguments,
+            config=config,
         )
     else:
         skipped: List[str] = []

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -237,6 +237,9 @@ import b
     with pytest.warns(UserWarning):
         main.main([str(python_file), "--recursive", "-fss"])
 
+    # warnings should be displayed when streaming input is provided with old flags as well
+    with pytest.warns(UserWarning):
+        main.main(["-sp", str(config_file), "-"], stdin=input_content)
 
 def test_isort_command():
     """Ensure ISortCommand got registered, otherwise setuptools error must have occured"""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -241,6 +241,7 @@ import b
     with pytest.warns(UserWarning):
         main.main(["-sp", str(config_file), "-"], stdin=input_content)
 
+
 def test_isort_command():
     """Ensure ISortCommand got registered, otherwise setuptools error must have occured"""
     assert main.ISortCommand


### PR DESCRIPTION
Fixes #1447: isort when ran from the CLI should use the same configuration setup for streamed in files as file names. Otherwise, the automatic removal of certain CLI only arguments will fail.