### PR TITLE
Resolve #1453: isort error when float to top on almost empty file. En…

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -86,7 +86,7 @@ def process(
                 if current:
                     parsed = parse.file_contents(current, config=config)
                     extra_space = ""
-                    while current[-1] == "\n":
+                    while current and current[-1] == "\n":
                         extra_space += "\n"
                         current = current[:-1]
                     extra_space = extra_space.replace("\n", "", 1)

--- a/isort/main.py
+++ b/isort/main.py
@@ -11,6 +11,7 @@ from warnings import warn
 
 from . import __version__, api, sections
 from .exceptions import FileSkipped
+from .format import create_terminal_printer
 from .logo import ASCII_ART
 from .profiles import profiles
 from .settings import VALID_PY_TARGETS, Config, WrapModes
@@ -103,6 +104,14 @@ def sort_imports(
     except (OSError, ValueError) as error:
         warn(f"Unable to parse file {file_name} due to {error}")
         return None
+    except Exception:
+        printer = create_terminal_printer(color=config.color_output)
+        printer.error(
+            f"Unrecoverable exception thrown when parsing {file_name}! "
+            "This should NEVER happen.\n"
+            "If encountered, please open an issue: https://github.com/PyCQA/isort/issues/new"
+        )
+        raise
 
 
 def iter_source_code(paths: Iterable[str], config: Config, skipped: List[str]) -> Iterator[str]:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -35,6 +35,17 @@ def test_sort_imports(tmpdir):
     assert main.sort_imports(str(tmp_file), config=skip_config, disregard_skip=False).skipped
 
 
+def test_sort_imports_error_handling(tmpdir, mocker, capsys):
+    tmp_file = tmpdir.join("file.py")
+    tmp_file.write("import os, sys\n")
+    mocker.patch("isort.core.process").side_effect = IndexError("Example unhandled exception")
+    with pytest.raises(IndexError):
+        main.sort_imports(str(tmp_file), DEFAULT_CONFIG, check=True).incorrectly_sorted
+
+    out, error = capsys.readouterr()
+    assert "Unrecoverable exception thrown when parsing" in error
+
+
 def test_parse_args():
     assert main.parse_args([]) == {}
     assert main.parse_args(["--multi-line", "1"]) == {"multi_line_output": WrapModes.VERTICAL}

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -911,3 +911,18 @@ def bar():
     pass
 '''
     )
+
+
+def test_empty_float_to_top_shouldnt_error_issue_1453():
+    """isort shouldn't error when float to top is set with a mostly empty file"""
+    assert isort.check_code(
+        """
+""",
+        show_diff=True,
+        float_to_top=True,
+    )
+    assert isort.check_code(
+        """
+""",
+        show_diff=True,
+    )


### PR DESCRIPTION
Fixes #1453:

- isort now handles whitespace only files with --float-to-top without an issue
- isort now returns the file name that caused an exception to occur for easier debugging.