### PR TITLE
Improve isort handling of noqa comments on wrap

### DIFF
--- a/isort/wrap.py
+++ b/isort/wrap.py
@@ -75,11 +75,13 @@ def line(content: str, line_separator: str, config: Config = DEFAULT_CONFIG) -> 
                 splitter
             ):
                 line_parts = re.split(exp, line_without_comment)
-                if comment:
+                if comment and not (config.use_parentheses and "noqa" in comment):
                     _comma_maybe = (
                         "," if (config.include_trailing_comma and config.use_parentheses) else ""
                     )
-                    line_parts[-1] = f"{line_parts[-1].strip()}{_comma_maybe}  #{comment}"
+                    line_parts[
+                        -1
+                    ] = f"{line_parts[-1].strip()}{_comma_maybe}{config.comment_prefix}{comment}"
                 next_line = []
                 while (len(content) + 2) > (
                     config.wrap_length or config.line_length
@@ -104,8 +106,14 @@ def line(content: str, line_separator: str, config: Config = DEFAULT_CONFIG) -> 
                             _separator = line_separator
                         else:
                             _separator = ""
+                        _comment = ""
+                        if comment and "noqa" in comment:
+                            _comment = f"{config.comment_prefix}{comment}"
+                            cont_line = cont_line.rstrip()
+                            _comma = "," if config.include_trailing_comma else ""
                         output = (
-                            f"{content}{splitter}({line_separator}{cont_line}{_comma}{_separator})"
+                            f"{content}{splitter}({_comment}"
+                            f"{line_separator}{cont_line}{_comma}{_separator})"
                         )
                     lines = output.split(line_separator)
                     if config.comment_prefix in lines[-1] and lines[-1].endswith(")"):

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -590,3 +590,70 @@ from pathlib import Path
         no_lines_before=["TYPING"],
         show_diff=True,
     )
+
+
+def test_isort_intelligently_places_noqa_comments_issue_1456():
+    assert isort.check_code(
+        """
+from my.horribly.long.import.line.that.just.keeps.on.going.and.going.and.going import (  # noqa
+    my_symbol,
+)
+""",
+        force_single_line=True,
+        show_diff=True,
+        multi_line_output=3,
+        include_trailing_comma=True,
+        force_grid_wrap=0,
+        use_parentheses=True,
+        line_length=79,
+    )
+
+    assert isort.check_code(
+        """
+from my.horribly.long.import.line.that.just.keeps.on.going.and.going.and.going import (
+    my_symbol,
+)
+""",
+        force_single_line=True,
+        show_diff=True,
+        multi_line_output=3,
+        include_trailing_comma=True,
+        force_grid_wrap=0,
+        use_parentheses=True,
+        line_length=79,
+    )
+
+    assert isort.check_code(
+        """
+from my.horribly.long.import.line.that.just.keeps.on.going.and.going.and.going import (  # noqa
+    my_symbol
+)
+""",
+        force_single_line=True,
+        use_parentheses=True,
+        multi_line_output=3,
+        line_length=79,
+        show_diff=True,
+    )
+
+    assert isort.check_code(
+        """
+from my.horribly.long.import.line.that.just.keeps.on.going.and.going.and.going import (
+    my_symbol
+)
+""",
+        force_single_line=True,
+        use_parentheses=True,
+        multi_line_output=3,
+        line_length=79,
+        show_diff=True,
+    )
+
+    # see: https://github.com/PyCQA/isort/issues/1415
+    assert isort.check_code(
+        "from dials.test.algorithms.spot_prediction."
+        "test_scan_static_reflection_predictor import (  # noqa: F401\n"
+        "    data as static_test,\n)\n",
+        profile="black",
+        show_diff=True,
+    )


### PR DESCRIPTION
Resolves #1456 and #1415: noqa comments shouldn't be moved to where flake8 can't see them