### PR TITLE
Fixed #1461: Quiet config option not respected by file API in some ci…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Find out more about isort's release policy [here](https://pycqa.github.io/isort/
 
 ### 5.6.0 TBD
   - Fixed #1463: Better interactive documentation for future option.
+  - Fixed #1461: Quiet config option not respected by file API in some circumstances.
 
 ### 5.5.1 September 4, 2020
   - Fixed #1454: Ensure indented import sections with import heading and a preceding comment don't cause import sorting loops.

--- a/isort/api.py
+++ b/isort/api.py
@@ -299,6 +299,7 @@ def sort_file(
     """
     with io.File.read(filename) as source_file:
         actual_file_path = file_path or source_file.path
+        config = _config(path=actual_file_path, config=config, **config_kwargs)
         changed: bool = False
         try:
             if write_to_stdout:
@@ -309,7 +310,6 @@ def sort_file(
                     file_path=actual_file_path,
                     disregard_skip=disregard_skip,
                     extension=extension,
-                    **config_kwargs,
                 )
             else:
                 tmp_file = source_file.path.with_suffix(source_file.path.suffix + ".isorted")
@@ -325,7 +325,6 @@ def sort_file(
                             file_path=actual_file_path,
                             disregard_skip=disregard_skip,
                             extension=extension,
-                            **config_kwargs,
                         )
                     if changed:
                         if show_diff or ask_to_apply:


### PR DESCRIPTION
Fixes #1461: the `isort.file` API call creates the config based on the passed in file at a point where it isn't seen when checking quiet option.