### PR TITLE
Issue/1475/improve unsupported config option error reporting

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -14,3 +14,4 @@ enabled = true
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+  max_line_length = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.3.0
+    rev: 5.5.2
     hooks:
       - id: isort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Find out more about isort's release policy [here](https://pycqa.github.io/isort/
 
 ### 5.6.0 TBD
   - Implemented #1433: Provide helpful feedback in case a custom config file is specified without a configuration.
+  - Improved handling of unsupported configuration option errors (see #1475).
   - Fixed #1463: Better interactive documentation for future option.
   - Fixed #1461: Quiet config option not respected by file API in some circumstances.
 

--- a/isort/exceptions.py
+++ b/isort/exceptions.py
@@ -1,4 +1,6 @@
 """All isort specific exception classes should be defined here"""
+from typing import Any, Dict
+
 from .profiles import profiles
 
 
@@ -132,3 +134,25 @@ class AssignmentsFormatMismatch(ISortError):
             "...\n\n"
         )
         self.code = code
+
+
+class UnsupportedSettings(ISortError):
+    """Raised when settings are passed into isort (either from config, CLI, or runtime)
+    that it doesn't support.
+    """
+
+    def _format_option(self, name: str, value: Any, source: str) -> str:
+        return f"\t- {name} = {value}  (source: '{source}')"
+
+    def __init__(self, unsupported_settings: Dict[str, Dict[str, str]]):
+        errors = "\n".join(
+            self._format_option(name, **option) for name, option in unsupported_settings.items()
+        )
+
+        super().__init__(
+            "isort was provided settings that it doesn't support:\n\n"
+            f"{errors}\n\n"
+            "For a complete and up-to-date listing of supported settings see: "
+            "https://pycqa.github.io/isort/docs/configuration/options/.\n"
+        )
+        self.unsupported_settings = unsupported_settings

--- a/isort/exceptions.py
+++ b/isort/exceptions.py
@@ -141,7 +141,8 @@ class UnsupportedSettings(ISortError):
     that it doesn't support.
     """
 
-    def _format_option(self, name: str, value: Any, source: str) -> str:
+    @staticmethod
+    def _format_option(name: str, value: Any, source: str) -> str:
         return f"\t- {name} = {value}  (source: '{source}')"
 
     def __init__(self, unsupported_settings: Dict[str, Dict[str, str]]):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -82,3 +82,11 @@ class TestAssignmentsFormatMismatch(TestISortError):
 
     def test_variables(self):
         assert self.instance.code == "print x"
+
+
+class TestUnsupportedSettings(TestISortError):
+    def setup_class(self):
+        self.instance = exceptions.UnsupportedSettings({"apply": {"value": "true", "source": "/"}})
+
+    def test_variables(self):
+        assert self.instance.unsupported_settings == {"apply": {"value": "true", "source": "/"}}

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -14,6 +14,14 @@ class TestConfig:
     def test_init(self):
         assert Config()
 
+    def test_init_unsupported_settings_fails_gracefully(self):
+        with pytest.raises(exceptions.UnsupportedSettings):
+            Config(apply=True)
+        try:
+            Config(apply=True)
+        except exceptions.UnsupportedSettings as error:
+            assert error.unsupported_settings == {"apply": {"value": True, "source": "runtime"}}
+
     def test_known_settings(self):
         assert Config(known_third_party=["one"]).known_third_party == frozenset({"one"})
         assert Config(known_thirdparty=["two"]).known_third_party == frozenset({"two"})


### PR DESCRIPTION
When unsupported config options are passed in either via a config file or runtime parameter, isort returns a confusing TypeError exception:

```python
Traceback (most recent call last):
  File "/Users/k/.cache/pre-commit/repoccvi_m_m/py_env-python3.8/bin/isort", line 8, in <module>
    sys.exit(main())
  File "/Users/k/.cache/pre-commit/repoccvi_m_m/py_env-python3.8/lib/python3.8/site-packages/isort/main.py", line 830, in main
    config = Config(**config_dict)
  File "/Users/k/.cache/pre-commit/repoccvi_m_m/py_env-python3.8/lib/python3.8/site-packages/isort/settings.py", line 426, in __init__
    super().__init__(sources=tuple(sources), **combined_config)  # type: ignore
TypeError: __init__() got an unexpected keyword argument 'apply'
```

Instead this pull request allows isort to return an exception which correctly states what the error is, and what the source of the config option is:

```
isort.exceptions.UnsupportedSettings: isort was provided settings that it doesn't support:

        - apply = true  (source: '/home/timothy/Projects/isort/.isort.cfg')

For a complete and up-to-date listing of supported settings see: https://pycqa.github.io/isort/docs/configuration/options/.
```