### PR TITLE
Issue/1482/fix pylama integration

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
     "template": "https://github.com/timothycrosley/cookiecutter-python/",
-    "commit": "4fe165a760a98a06d3fbef89aae3149767e489f3",
+    "commit": "ff6836bfaa247c65ff50b39c520ed12d91bf5a20",
     "context": {
         "cookiecutter": {
             "full_name": "Timothy Crosley",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Find out more about isort's release policy [here](https://pycqa.github.io/isort/
   - Improved handling of unsupported configuration option errors (see #1475).
   - Fixed #1463: Better interactive documentation for future option.
   - Fixed #1461: Quiet config option not respected by file API in some circumstances.
+  - Fixed #1482: pylama integration is not working correctly out-of-the-box.
 
 ### 5.5.2 [Hotfix] September 9, 2020
   - Fixed #1469: --diff option is ignored when input is from stdin.

--- a/isort/pylama_isort.py
+++ b/isort/pylama_isort.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List
 
 from pylama.lint import Linter as BaseLinter
 
+from isort.exceptions import FileSkipped
+
 from . import api
 
 
@@ -25,9 +27,17 @@ class Linter(BaseLinter):
     def run(self, path: str, **meta: Any) -> List[Dict[str, Any]]:
         """Lint the file. Return an array of error dicts if appropriate."""
         with supress_stdout():
-            if not api.check_file(path):
-                return [
-                    {"lnum": 0, "col": 0, "text": "Incorrectly sorted imports.", "type": "ISORT"}
-                ]
-            else:
-                return []
+            try:
+                if not api.check_file(path, disregard_skip=False):
+                    return [
+                        {
+                            "lnum": 0,
+                            "col": 0,
+                            "text": "Incorrectly sorted imports.",
+                            "type": "ISORT",
+                        }
+                    ]
+            except FileSkipped:
+                pass
+
+            return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ isort = "isort.main:main"
 isort = "isort.main:ISortCommand"
 
 [tool.poetry.plugins."pylama.linter"]
-isort = "isort = isort.pylama_isort:Linter"
+isort = "isort.pylama_isort:Linter"
 
 [tool.portray.mkdocs]
 edit_uri = "https://github.com/pycqa/isort/edit/develop/"

--- a/tests/unit/test_pylama_isort.py
+++ b/tests/unit/test_pylama_isort.py
@@ -17,3 +17,8 @@ class TestLinter:
         incorrect = tmpdir.join("incorrect.py")
         incorrect.write("import b\nimport a\n")
         assert self.instance.run(str(incorrect))
+
+    def test_skip(self, src_dir, tmpdir):
+        incorrect = tmpdir.join("incorrect.py")
+        incorrect.write("# isort: skip_file\nimport b\nimport a\n")
+        assert not self.instance.run(str(incorrect))


### PR DESCRIPTION
Fixes #1482: pylama integration no longer works well directly after a pip install of isort due to: misconfigured plugin entry in pyproject.toml & lack of support for skipped files. This PR addresses both these issues.