### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,9 +533,9 @@ isort --rm "os.system" *.py
 The `--check-only` option
 -------------------------
 
-isort can also be used to used to verify that code is correctly
-formatted by running it with `-c`. Any files that contain incorrectly
-sorted and/or formatted imports will be outputted to `stderr`.
+isort can also be used to verify that code is correctly formatted
+by running it with `-c`. Any files that contain incorrectly sorted
+and/or formatted imports will be outputted to `stderr`.
 
 ```bash
 isort **/*.py -c -v


### PR DESCRIPTION
Remove redundant `used to` from README.md