### PR TITLE
Issue/1505/isort crash on pyramid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Find out more about isort's release policy [here](https://pycqa.github.io/isort/
   - Fixed #1482: pylama integration is not working correctly out-of-the-box.
   - Fixed #1492: --check does not work with stdin source.
   - Fixed #1499: isort gets confused by single line, multi-line style comments when using float-to-top.
+  - Fixed #1505: Support case where known_SECTION points to a section not listed in sections.
 
 ### 5.5.3 [Hotfix] September 20, 2020
   - Fixed #1488: in rare cases isort can mangle `yield from` or `raise from` statements.

--- a/isort/place.py
+++ b/isort/place.py
@@ -54,7 +54,7 @@ def _known_pattern(name: str, config: Config) -> Optional[Tuple[str, str]]:
     module_names_to_check = (".".join(parts[:first_k]) for first_k in range(len(parts), 0, -1))
     for module_name_to_check in module_names_to_check:
         for pattern, placement in config.known_patterns:
-            if pattern.match(module_name_to_check):
+            if placement in config.sections and pattern.match(module_name_to_check):
                 return (placement, f"Matched configured known pattern {pattern}")
 
     return None

--- a/tests/integration/test_projects_using_isort.py
+++ b/tests/integration/test_projects_using_isort.py
@@ -127,3 +127,11 @@ def test_attrs(tmpdir):
 def test_datadog_integrations_core(tmpdir):
     git_clone("https://github.com/DataDog/integrations-core.git", tmpdir)
     run_isort([str(tmpdir)])
+
+
+def test_pyramid(tmpdir):
+    git_clone("https://github.com/Pylons/pyramid.git", tmpdir)
+    run_isort(
+        str(target_dir)
+        for target_dir in (tmpdir / "src" / "pyramid", tmpdir / "tests", tmpdir / "setup.py")
+    )

--- a/tests/unit/test_place.py
+++ b/tests/unit/test_place.py
@@ -20,3 +20,10 @@ def test_extra_standard_library(src_path):
     )
     assert place_tester("os") == sections.STDLIB
     assert place_tester("hug") == sections.STDLIB
+
+
+def test_no_standard_library_placement():
+    assert place.module_with_reason(
+        "pathlib", config=Config(sections=["THIRDPARTY"], default_section="THIRDPARTY")
+    ) == ("THIRDPARTY", "Default option in Config or universal default.")
+    assert place.module("pathlib") == "STDLIB"


### PR DESCRIPTION
Fixes #1505: ensures isort cleanly supports the case where a known_SECTION listed in the Config object doesn't exist have a corresponding section defined.