### PR TITLE
Improve PyCharm Profile

### DIFF
--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -30,6 +30,7 @@ To use any of the listed profiles, use `isort --profile PROFILE_NAME` from the c
 
  - **multi_line_output**: `3`
  - **force_grid_wrap**: `2`
+ - **lines_after_imports**: `2`
 
 #google
 

--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -15,7 +15,11 @@ django = {
     "multi_line_output": 5,
     "line_length": 79,
 }
-pycharm = {"multi_line_output": 3, "force_grid_wrap": 2}
+pycharm = {
+    "multi_line_output": 3,
+    "force_grid_wrap": 2,
+    "lines_after_imports": 2,
+}
 google = {
     "force_single_line": True,
     "force_sort_within_sections": True,


### PR DESCRIPTION
PyCharm by default adds 2 lines after imports using the "Optimize Imports (control+option+o)" action.