### PR TITLE
Issue/1523/isort removes non as imports on same line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Find out more about isort's release policy [here](https://pycqa.github.io/isort/
   - Fixed #1492: --check does not work with stdin source.
   - Fixed #1499: isort gets confused by single line, multi-line style comments when using float-to-top.
   - Fixed #1525: Some warnings can't be disabled with --quiet.
-Potentially breaking changes:
+  - Fixed #1523: in rare cases isort can ignore direct from import if as import is also on same line.
+
+  Potentially breaking changes:
   - Fixed #1486: "Google" profile is not quite Google style.
   - Fixed "PyCharm" profile to always add 2 lines to be consistent with what PyCharm "Optimize Imports" does.
 

--- a/isort/parse.py
+++ b/isort/parse.py
@@ -336,10 +336,10 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
                 item.replace("{|", "{ ").replace("|}", " }")
                 for item in _strip_syntax(import_string).split()
             ]
-            straight_import = True
+
             attach_comments_to: Optional[List[Any]] = None
             if "as" in just_imports and (just_imports.index("as") + 1) < len(just_imports):
-                straight_import = False
+                straight_imports = set()
                 while "as" in just_imports:
                     nested_module = None
                     as_index = just_imports.index("as")
@@ -379,6 +379,8 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
                                 module, []
                             )
                     del just_imports[as_index : as_index + 2]
+            else:
+                straight_imports = set(just_imports[1:])
 
             if type_of_import == "from":
                 import_from = just_imports.pop(0)

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -966,6 +966,29 @@ def test_check_newline_in_imports(capsys) -> None:
     out, _ = capsys.readouterr()
     assert "SUCCESS" in out
 
+    # if the verbose is only on modified outputs no output will be given
+    assert api.check_code_string(
+        code=test_input,
+        multi_line_output=WrapModes.VERTICAL_HANGING_INDENT,
+        line_length=20,
+        verbose=True,
+        only_modified=True,
+    )
+    out, _ = capsys.readouterr()
+    assert not out
+
+    # we can make the input invalid to again see output
+    test_input = "from lib1 import (\n    sub2,\n    sub1,\n    sub3\n)\n"
+    assert not api.check_code_string(
+        code=test_input,
+        multi_line_output=WrapModes.VERTICAL_HANGING_INDENT,
+        line_length=20,
+        verbose=True,
+        only_modified=True,
+    )
+    out, _ = capsys.readouterr()
+    assert out
+
 
 def test_forced_separate() -> None:
     """Ensure that forcing certain sub modules to show separately works as expected."""

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -1273,3 +1273,14 @@ def d():
 ''',
         show_diff=True,
     )
+
+
+def test_isort_should_keep_all_as_and_non_as_imports_issue_1523():
+    """isort should keep as and non-as imports of the same path that happen to exist within the
+    same statement.
+    See: https://github.com/PyCQA/isort/issues/1523.
+    """
+    assert isort.check_code(
+        """
+from selenium.webdriver import Remote, Remote as Driver
+""", show_diff=True, combine_as_imports=True)

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -1283,4 +1283,7 @@ def test_isort_should_keep_all_as_and_non_as_imports_issue_1523():
     assert isort.check_code(
         """
 from selenium.webdriver import Remote, Remote as Driver
-""", show_diff=True, combine_as_imports=True)
+""",
+        show_diff=True,
+        combine_as_imports=True,
+    )


### PR DESCRIPTION
Fixes #1532: isort missing non-as imports on same line and for same path as an as import