### PR TITLE
Let pre-commit sort pxd files too

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,6 @@
     entry: isort
     require_serial: true
     language: python
-    types: [python]
+    files: '.pxd$|.py$'
+    types: [file]
     args: ['--filter-files']

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     entry: isort
     require_serial: true
     language: python
-    types: [python, cython, pyi]
+    types: [python]
     args: ['--filter-files']

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,4 @@
     require_serial: true
     language: python
     files: '.pxd$|.py$'
-    types: [file]
     args: ['--filter-files']

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     entry: isort
     require_serial: true
     language: python
-    files: '.pxd$|.py$'
+    types: [python, cython, pyi]
     args: ['--filter-files']

--- a/docs/upgrade_guides/5.0.0.md
+++ b/docs/upgrade_guides/5.0.0.md
@@ -82,9 +82,17 @@ isort now includes an optimized precommit configuration in the repo itself. To u
 
 ```
   - repo: https://github.com/pycqa/isort
-    rev: 5.3.2
+    rev: 5.6.3
     hooks:
       - id: isort
+        name: isort (python)
+        types: [python]
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]
 ```
 
 under the `repos` section of your projects `.pre-commit-config.yaml` config.

--- a/docs/upgrade_guides/5.0.0.md
+++ b/docs/upgrade_guides/5.0.0.md
@@ -86,7 +86,6 @@ isort now includes an optimized precommit configuration in the repo itself. To u
     hooks:
       - id: isort
         name: isort (python)
-        types: [python]
       - id: isort
         name: isort (cython)
         types: [cython]


### PR DESCRIPTION
In #1494, it looks like support for `.pxd` files was added. However, these are currently ignored when running isort in pre-commit because there is `types: [python]`