### PR TITLE
Prevent installation of the "tests" package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,5 +101,5 @@ logo = "art/logo.png"
 palette = {scheme = "isort"}
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ classifiers = [
 urls = { Changelog = "https://github.com/pycqa/isort/blob/master/CHANGELOG.md" }
 packages = [
     { include = "isort" },
-    { include = "tests", format = "sdist" },
+]
+include = [
+    { path = "tests", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Hi,
Tests should not be listed under packages, otherwise setup.py attempts to install a "tests" package, causing potential clashes with other packages.


Comparison of the generated setup.py files before and after the change:
```diff
--- a/setup.py   2020-10-10 19:30:58.737358684 +0200
+++ b/setup.py  2020-10-10 19:31:06.787331020 +0200
@@ -6,28 +6,10 @@
  'isort._future',
  'isort._vendored.toml',
  'isort.deprecated',
- 'isort.stdlibs',
- 'tests',
- 'tests.integration',
- 'tests.unit',
- 'tests.unit.example_projects.namespaces.almost-implicit.root',
- 'tests.unit.example_projects.namespaces.almost-implicit.root.nested',
- 'tests.unit.example_projects.namespaces.implicit.root.nested',
- 'tests.unit.example_projects.namespaces.none.root',
- 'tests.unit.example_projects.namespaces.none.root.nested',
- 'tests.unit.example_projects.namespaces.pkg_resource.root',
- 'tests.unit.example_projects.namespaces.pkg_resource.root.nested',
- 'tests.unit.example_projects.namespaces.pkgutil.root',
- 'tests.unit.example_projects.namespaces.pkgutil.root.nested',
- 'tests.unit.profiles']
+ 'isort.stdlibs']
 
 package_data = \
-{'': ['*'],
- 'tests.unit': ['example_projects/namespaces/almost-implicit/*',
-                'example_projects/namespaces/implicit/*',
-                'example_projects/namespaces/none/*',
-                'example_projects/namespaces/pkg_resource/*',
-                'example_projects/namespaces/pkgutil/*']}
+{'': ['*']}
 
 extras_require = \
 {'colors': ['colorama>=0.4.3,<0.5.0'],
```