### PR TITLE
Always append missing default sections

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -381,9 +381,11 @@ class Config(_Config):
 
             combined_config[key] = type(default_value)(value)
 
-        for section in combined_config.get("sections", ()):
+        missing_sections = list(SECTION_DEFAULTS)
+        defined_sections = combined_config.get("sections", ())
+        for section in defined_sections:
             if section in SECTION_DEFAULTS:
-                continue
+                missing_sections.remove(section)
             elif not section.lower() in known_other:
                 config_keys = ", ".join(known_other.keys())
                 warn(
@@ -391,6 +393,12 @@ class Config(_Config):
                     "is defined. "
                     f"The following known_SECTION config options are defined: {config_keys}."
                 )
+        if defined_sections and missing_sections:
+            combined_config["sections"] = defined_sections + tuple(missing_sections)
+            warn(
+                "`sections` setting was defined without the default sections "
+                f"{tuple(missing_sections)}. These have now been appended."
+            )
 
         if "directory" not in combined_config:
             combined_config["directory"] = (


### PR DESCRIPTION
Previously, if any of the default sections were omitted in a setup.cfg that defined a `sections` block, isort would throw an exception (see linked issues). Any omitted default sections are now appended to the defined sections, in their default order, and a UserWarning is generated to let the user know as much.

Fixes #1570 #1562 