### PR TITLE
Handle errors when default section(s) forgotten

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ of:
 FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 ```
 
-to your preference:
+to your preference (if defined, omitting a default section may cause errors):
 
 ```ini
 sections=FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -108,7 +108,9 @@ Forces line endings to the specified value. If not set, values will be guessed p
 
 ## Sections
 
-**No Description**
+Specifies a custom ordering for sections. Any custom defined sections should also be
+included in this ordering. Omitting any of the default sections from this tuple may
+result in unexpected sorting or an exception being raised.
 
 **Type:** Tuple  
 **Default:** `('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')`  

--- a/isort/main.py
+++ b/isort/main.py
@@ -110,13 +110,21 @@ def sort_imports(
             warn(f"Encoding not supported for {file_name}")
         return SortAttempt(incorrectly_sorted, skipped, False)
     except Exception:
-        printer = create_terminal_printer(color=config.color_output)
-        printer.error(
-            f"Unrecoverable exception thrown when parsing {file_name}! "
-            "This should NEVER happen.\n"
-            "If encountered, please open an issue: https://github.com/PyCQA/isort/issues/new"
-        )
+        _print_hard_fail(config, offending_file=file_name)
         raise
+
+
+def _print_hard_fail(
+    config: Config, offending_file: Optional[str] = None, message: Optional[str] = None
+) -> None:
+    """Fail on unrecoverable exception with custom message."""
+    message = message or (
+        f"Unrecoverable exception thrown when parsing {offending_file or ''}!"
+        "This should NEVER happen.\n"
+        "If encountered, please open an issue: https://github.com/PyCQA/isort/issues/new"
+    )
+    printer = create_terminal_printer(color=config.color_output)
+    printer.error(message)
 
 
 def iter_source_code(


### PR DESCRIPTION
Trying this one from a different angle...

Previously, if any of the default sections were omitted in a setup.cfg that defined a sections block, isort would throw an exception (see linked issues). Any omitted default sections are now appended to `chain(sections, forced_separate)` during parsing. Duplicates are avoided and the correct (default) order is maintained with an OrderedDict().

Fixes #1570 #1562 