### PR TITLE
fix deepsource.io warnings

### DIFF
--- a/isort/api.py
+++ b/isort/api.py
@@ -216,30 +216,30 @@ def check_stream(
         if config.verbose and not config.only_modified:
             printer.success(f"{file_path or ''} Everything Looks Good!")
         return True
-    else:
-        printer.error(f"{file_path or ''} Imports are incorrectly sorted and/or formatted.")
-        if show_diff:
-            output_stream = StringIO()
-            input_stream.seek(0)
-            file_contents = input_stream.read()
-            sort_stream(
-                input_stream=StringIO(file_contents),
-                output_stream=output_stream,
-                extension=extension,
-                config=config,
-                file_path=file_path,
-                disregard_skip=disregard_skip,
-            )
-            output_stream.seek(0)
 
-            show_unified_diff(
-                file_input=file_contents,
-                file_output=output_stream.read(),
-                file_path=file_path,
-                output=None if show_diff is True else cast(TextIO, show_diff),
-                color_output=config.color_output,
-            )
-        return False
+    printer.error(f"{file_path or ''} Imports are incorrectly sorted and/or formatted.")
+    if show_diff:
+        output_stream = StringIO()
+        input_stream.seek(0)
+        file_contents = input_stream.read()
+        sort_stream(
+            input_stream=StringIO(file_contents),
+            output_stream=output_stream,
+            extension=extension,
+            config=config,
+            file_path=file_path,
+            disregard_skip=disregard_skip,
+        )
+        output_stream.seek(0)
+
+        show_unified_diff(
+            file_input=file_contents,
+            file_output=output_stream.read(),
+            file_path=file_path,
+            output=None if show_diff is True else cast(TextIO, show_diff),
+            color_output=config.color_output,
+        )
+    return False
 
 
 def check_file(

--- a/isort/comments.py
+++ b/isort/comments.py
@@ -24,9 +24,9 @@ def add_to_line(
 
     if not comments:
         return original_string
-    else:
-        unique_comments: List[str] = []
-        for comment in comments:
-            if comment not in unique_comments:
-                unique_comments.append(comment)
-        return f"{parse(original_string)[0]}{comment_prefix} {'; '.join(unique_comments)}"
+
+    unique_comments: List[str] = []
+    for comment in comments:
+        if comment not in unique_comments:
+            unique_comments.append(comment)
+    return f"{parse(original_string)[0]}{comment_prefix} {'; '.join(unique_comments)}"

--- a/isort/core.py
+++ b/isort/core.py
@@ -70,8 +70,9 @@ def process(
     end_of_file: bool = False
     verbose_output: List[str] = []
     all_imports: List[str] = []
+
+    _output_stream = output_stream  # Used if imports_only == True
     if imports_only:
-        _output_stream = output_stream
 
         class DevNull(StringIO):
             def write(self, *a, **kw):
@@ -435,5 +436,4 @@ def _has_changed(before: str, after: str, line_separator: str, ignore_whitespace
             remove_whitespace(before, line_separator=line_separator).strip()
             != remove_whitespace(after, line_separator=line_separator).strip()
         )
-    else:
-        return before.strip() != after.strip()
+    return before.strip() != after.strip()

--- a/isort/deprecated/finders.py
+++ b/isort/deprecated/finders.py
@@ -188,9 +188,9 @@ class PathFinder(BaseFinder):
                     or (self.virtual_env and self.virtual_env_src in prefix)
                 ):
                     return sections.THIRDPARTY
-                elif os.path.normcase(prefix) == self.stdlib_lib_prefix:
+                if os.path.normcase(prefix) == self.stdlib_lib_prefix:
                     return sections.STDLIB
-                elif self.conda_env and self.conda_env in prefix:
+                if self.conda_env and self.conda_env in prefix:
                     return sections.THIRDPARTY
                 for src_path in self.config.src_paths:
                     if src_path in path_obj.parents and not self.config.is_skipped(path_obj):

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -41,7 +41,7 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
     """
     if sort_type == "assignments":
         return assignments(code)
-    elif sort_type not in type_mapping:
+    if sort_type not in type_mapping:
         raise ValueError(
             "Trying to sort using an undefined sort_type. "
             f"Defined sort types are {', '.join(type_mapping.keys())}."

--- a/isort/main.py
+++ b/isort/main.py
@@ -81,27 +81,27 @@ def sort_imports(
     write_to_stdout: bool = False,
     **kwargs: Any,
 ) -> Optional[SortAttempt]:
+    incorrectly_sorted: bool = False
+    skipped: bool = False
     try:
-        incorrectly_sorted: bool = False
-        skipped: bool = False
         if check:
             try:
                 incorrectly_sorted = not api.check_file(file_name, config=config, **kwargs)
             except FileSkipped:
                 skipped = True
             return SortAttempt(incorrectly_sorted, skipped, True)
-        else:
-            try:
-                incorrectly_sorted = not api.sort_file(
-                    file_name,
-                    config=config,
-                    ask_to_apply=ask_to_apply,
-                    write_to_stdout=write_to_stdout,
-                    **kwargs,
-                )
-            except FileSkipped:
-                skipped = True
-            return SortAttempt(incorrectly_sorted, skipped, True)
+
+        try:
+            incorrectly_sorted = not api.sort_file(
+                file_name,
+                config=config,
+                ask_to_apply=ask_to_apply,
+                write_to_stdout=write_to_stdout,
+                **kwargs,
+            )
+        except FileSkipped:
+            skipped = True
+        return SortAttempt(incorrectly_sorted, skipped, True)
     except (OSError, ValueError) as error:
         warn(f"Unable to parse file {file_name} due to {error}")
         return None
@@ -816,14 +816,13 @@ def _preconvert(item):
     """Preconverts objects from native types into JSONifyiable types"""
     if isinstance(item, (set, frozenset)):
         return list(item)
-    elif isinstance(item, WrapModes):
+    if isinstance(item, WrapModes):
         return item.name
-    elif isinstance(item, Path):
+    if isinstance(item, Path):
         return str(item)
-    elif callable(item) and hasattr(item, "__name__"):
+    if callable(item) and hasattr(item, "__name__"):
         return item.__name__
-    else:
-        raise TypeError("Unserializable object {} of type {}".format(item, type(item)))
+    raise TypeError("Unserializable object {} of type {}".format(item, type(item)))
 
 
 def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = None) -> None:
@@ -855,8 +854,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
         print(QUICK_GUIDE)
         if arguments:
             sys.exit("Error: arguments passed in without any paths or content.")
-        else:
-            return
+        return
     if "settings_path" not in arguments:
         arguments["settings_path"] = (
             os.path.abspath(file_names[0] if file_names else ".") or os.getcwd()

--- a/isort/output.py
+++ b/isort/output.py
@@ -615,5 +615,4 @@ def _with_star_comments(parsed: parse.ParsedContent, module: str, comments: List
     star_comment = parsed.categorized_comments["nested"].get(module, {}).pop("*", None)
     if star_comment:
         return comments + [star_comment]
-    else:
-        return comments
+    return comments

--- a/isort/parse.py
+++ b/isort/parse.py
@@ -31,10 +31,9 @@ if TYPE_CHECKING:
 def _infer_line_separator(contents: str) -> str:
     if "\r\n" in contents:
         return "\r\n"
-    elif "\r" in contents:
+    if "\r" in contents:
         return "\r"
-    else:
-        return "\n"
+    return "\n"
 
 
 def _normalize_line(raw_line: str) -> Tuple[str, str]:
@@ -55,11 +54,11 @@ def import_type(line: str, config: Config = DEFAULT_CONFIG) -> Optional[str]:
     """If the current line is an import line it will return its type (from or straight)"""
     if config.honor_noqa and line.lower().rstrip().endswith("noqa"):
         return None
-    elif "isort:skip" in line or "isort: skip" in line or "isort: split" in line:
+    if "isort:skip" in line or "isort: skip" in line or "isort: split" in line:
         return None
-    elif line.startswith(("import ", "cimport ")):
+    if line.startswith(("import ", "cimport ")):
         return "straight"
-    elif line.startswith("from "):
+    if line.startswith("from "):
         return "from"
     return None
 
@@ -369,6 +368,7 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
             attach_comments_to: Optional[List[Any]] = None
             direct_imports = just_imports[1:]
             straight_import = True
+            top_level_module = ""
             if "as" in just_imports and (just_imports.index("as") + 1) < len(just_imports):
                 straight_import = False
                 while "as" in just_imports:
@@ -443,7 +443,7 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
                     attach_comments_to = categorized_comments["from"].setdefault(import_from, [])
 
                 if len(out_lines) > max(import_index, 1) - 1:
-                    last = out_lines and out_lines[-1].rstrip() or ""
+                    last = out_lines[-1].rstrip() if out_lines else ""
                     while (
                         last.startswith("#")
                         and not last.endswith('"""')
@@ -489,7 +489,7 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
 
                     if len(out_lines) > max(import_index, +1, 1) - 1:
 
-                        last = out_lines and out_lines[-1].rstrip() or ""
+                        last = out_lines[-1].rstrip() if out_lines else ""
                         while (
                             last.startswith("#")
                             and not last.endswith('"""')

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -468,7 +468,7 @@ class Config(_Config):
         ext = ext.lstrip(".")
         if ext in self.supported_extensions:
             return True
-        elif ext in self.blocked_extensions:
+        if ext in self.blocked_extensions:
             return False
 
         # Skip editor backup files.

--- a/isort/setuptools_commands.py
+++ b/isort/setuptools_commands.py
@@ -24,7 +24,7 @@ class ISortCommand(setuptools.Command):
             setattr(self, key, value)
 
     def finalize_options(self) -> None:
-        "Get options from config files."
+        """Get options from config files."""
         self.arguments: Dict[str, Any] = {}  # skipcq: PYL-W0201
         self.arguments["settings_path"] = os.getcwd()
 

--- a/isort/sorting.py
+++ b/isort/sorting.py
@@ -47,7 +47,7 @@ def module_key(
         or (config.length_sort_straight and straight_import)
         or str(section_name).lower() in config.length_sort_sections
     )
-    _length_sort_maybe = length_sort and (str(len(module_name)) + ":" + module_name) or module_name
+    _length_sort_maybe = (str(len(module_name)) + ":" + module_name) if length_sort else module_name
     return f"{module_name in config.force_to_top and 'A' or 'B'}{prefix}{_length_sort_maybe}"
 
 

--- a/isort/stdlibs/__init__.py
+++ b/isort/stdlibs/__init__.py
@@ -1,1 +1,2 @@
-from . import all, py2, py3, py27, py35, py36, py37, py38, py39
+from . import all as _all
+from . import py2, py3, py27, py35, py36, py37, py38, py39

--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -250,15 +250,13 @@ def noqa(**interface):
             <= interface["line_length"]
         ):
             return f"{retval}{interface['comment_prefix']} {comment_str}"
-        elif "NOQA" in interface["comments"]:
+        if "NOQA" in interface["comments"]:
             return f"{retval}{interface['comment_prefix']} {comment_str}"
-        else:
-            return f"{retval}{interface['comment_prefix']} NOQA {comment_str}"
-    else:
-        if len(retval) <= interface["line_length"]:
-            return retval
-        else:
-            return f"{retval}{interface['comment_prefix']} NOQA"
+        return f"{retval}{interface['comment_prefix']} NOQA {comment_str}"
+
+    if len(retval) <= interface["line_length"]:
+        return retval
+    return f"{retval}{interface['comment_prefix']} NOQA"
 
 
 @_wrap_mode


### PR DESCRIPTION
"Safe" warnings, regarding style, and ternary operators were fixed.

added some variable initialisations to suppress false-positive "possibly unbound" warnings

"Unused arguments" warnings were left untouched, as they might be used as kwargs and renaming/removing them might break stuff.

Fixes #1569 (does more than the issue suggests, but the deepsource.io link was the basis of the commit.