### PR TITLE
Group options in help

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -203,7 +203,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--help",
         action="help",
         default=argparse.SUPPRESS,
-        help=_('show this help message and exit'),
+        help=_("show this help message and exit"),
     )
     general_group.add_argument(
         "-V",

--- a/isort/main.py
+++ b/isort/main.py
@@ -4,6 +4,7 @@ import functools
 import json
 import os
 import sys
+from gettext import gettext as _
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Set
@@ -186,61 +187,94 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "interactive behavior."
         " "
         "If you've used isort 4 but are new to isort 5, see the upgrading guide:"
-        "https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/."
+        "https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/.",
+        add_help=False,  # prevent help option from appearing in "optional arguments" group
     )
-    inline_args_group = parser.add_mutually_exclusive_group()
-    parser.add_argument(
-        "--src",
-        "--src-path",
-        dest="src_paths",
-        action="append",
-        help="Add an explicitly defined source path "
-        "(modules within src paths have their imports automatically categorized as first_party).",
+
+    general_group = parser.add_argument_group("general options")
+    target_group = parser.add_argument_group("target options")
+    output_group = parser.add_argument_group("general output options")
+    inline_args_group = output_group.add_mutually_exclusive_group()
+    section_group = parser.add_argument_group("section output options")
+    deprecated_group = parser.add_argument_group("deprecated options")
+
+    general_group.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help=_('show this help message and exit'),
     )
-    parser.add_argument(
-        "-a",
-        "--add-import",
-        dest="add_imports",
-        action="append",
-        help="Adds the specified import line to all files, "
-        "automatically determining correct placement.",
-    )
-    parser.add_argument(
-        "--append",
-        "--append-only",
-        dest="append_only",
+    general_group.add_argument(
+        "-V",
+        "--version",
         action="store_true",
-        help="Only adds the imports specified in --add-imports if the file"
-        " contains existing imports.",
+        dest="show_version",
+        help="Displays the currently installed version of isort.",
     )
-    parser.add_argument(
-        "--ac",
-        "--atomic",
-        dest="atomic",
+    general_group.add_argument(
+        "--vn",
+        "--version-number",
+        action="version",
+        version=__version__,
+        help="Returns just the current version number without the logo",
+    )
+    general_group.add_argument(
+        "-v",
+        "--verbose",
         action="store_true",
-        help="Ensures the output doesn't save if the resulting file contains syntax errors.",
+        dest="verbose",
+        help="Shows verbose output, such as when files are skipped or when a check is successful.",
     )
-    parser.add_argument(
-        "--af",
-        "--force-adds",
-        dest="force_adds",
+    general_group.add_argument(
+        "--only-modified",
+        "--om",
+        dest="only_modified",
         action="store_true",
-        help="Forces import adds even if the original file is empty.",
+        help="Suppresses verbose output for non-modified files.",
     )
-    parser.add_argument(
-        "-b",
-        "--builtin",
-        dest="known_standard_library",
-        action="append",
-        help="Force isort to recognize a module as part of Python's standard library.",
+    general_group.add_argument(
+        "--dedup-headings",
+        dest="dedup_headings",
+        action="store_true",
+        help="Tells isort to only show an identical custom import heading comment once, even if"
+        " there are multiple sections with the comment set.",
     )
-    parser.add_argument(
-        "--extra-builtin",
-        dest="extra_standard_library",
-        action="append",
-        help="Extra modules to be included in the list of ones in Python's standard library.",
+    general_group.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        dest="quiet",
+        help="Shows extra quiet output, only errors are outputted.",
     )
-    parser.add_argument(
+    general_group.add_argument(
+        "-d",
+        "--stdout",
+        help="Force resulting output to stdout, instead of in-place.",
+        dest="write_to_stdout",
+        action="store_true",
+    )
+    general_group.add_argument(
+        "--show-config",
+        dest="show_config",
+        action="store_true",
+        help="See isort's determined config, as well as sources of config options.",
+    )
+    general_group.add_argument(
+        "--show-files",
+        dest="show_files",
+        action="store_true",
+        help="See the files isort will be ran against with the current config options.",
+    )
+    general_group.add_argument(
+        "--df",
+        "--diff",
+        dest="show_diff",
+        action="store_true",
+        help="Prints a diff of all the changes isort would make to a file, instead of "
+        "changing it in place",
+    )
+    general_group.add_argument(
         "-c",
         "--check-only",
         "--check",
@@ -249,14 +283,155 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Checks the file for unsorted / unformatted imports and prints them to the "
         "command line without modifying the file.",
     )
-    parser.add_argument(
+    general_group.add_argument(
+        "--ws",
+        "--ignore-whitespace",
+        action="store_true",
+        dest="ignore_whitespace",
+        help="Tells isort to ignore whitespace differences when --check-only is being used.",
+    )
+    general_group.add_argument(
+        "--sp",
+        "--settings-path",
+        "--settings-file",
+        "--settings",
+        dest="settings_path",
+        help="Explicitly set the settings path or file instead of auto determining "
+        "based on file location.",
+    )
+    general_group.add_argument(
+        "--profile",
+        dest="profile",
+        type=str,
+        help="Base profile type to use for configuration. "
+        f"Profiles include: {', '.join(profiles.keys())}. As well as any shared profiles.",
+    )
+    general_group.add_argument(
+        "--old-finders",
+        "--magic-placement",
+        dest="old_finders",
+        action="store_true",
+        help="Use the old deprecated finder logic that relies on environment introspection magic.",
+    )
+    general_group.add_argument(
+        "-j", "--jobs", help="Number of files to process in parallel.", dest="jobs", type=int
+    )
+    general_group.add_argument(
+        "--ac",
+        "--atomic",
+        dest="atomic",
+        action="store_true",
+        help="Ensures the output doesn't save if the resulting file contains syntax errors.",
+    )
+    general_group.add_argument(
+        "--interactive",
+        dest="ask_to_apply",
+        action="store_true",
+        help="Tells isort to apply changes interactively.",
+    )
+
+    target_group.add_argument(
+        "files", nargs="*", help="One or more Python source files that need their imports sorted."
+    )
+    target_group.add_argument(
+        "--filter-files",
+        dest="filter_files",
+        action="store_true",
+        help="Tells isort to filter files even when they are explicitly passed in as "
+        "part of the CLI command.",
+    )
+    target_group.add_argument(
+        "-s",
+        "--skip",
+        help="Files that sort imports should skip over. If you want to skip multiple "
+        "files you should specify twice: --skip file1 --skip file2.",
+        dest="skip",
+        action="append",
+    )
+    target_group.add_argument(
+        "--sg",
+        "--skip-glob",
+        help="Files that sort imports should skip over.",
+        dest="skip_glob",
+        action="append",
+    )
+    target_group.add_argument(
+        "--gitignore",
+        "--skip-gitignore",
+        action="store_true",
+        dest="skip_gitignore",
+        help="Treat project as a git repository and ignore files listed in .gitignore",
+    )
+    target_group.add_argument(
+        "--ext",
+        "--extension",
+        "--supported-extension",
+        dest="supported_extensions",
+        action="append",
+        help="Specifies what extensions isort can be ran against.",
+    )
+    target_group.add_argument(
+        "--blocked-extension",
+        dest="blocked_extensions",
+        action="append",
+        help="Specifies what extensions isort can never be ran against.",
+    )
+    target_group.add_argument(
+        "--dont-follow-links",
+        dest="dont_follow_links",
+        action="store_true",
+        help="Tells isort not to follow symlinks that are encountered when running recursively.",
+    )
+
+    output_group.add_argument(
+        "-a",
+        "--add-import",
+        dest="add_imports",
+        action="append",
+        help="Adds the specified import line to all files, "
+        "automatically determining correct placement.",
+    )
+    output_group.add_argument(
+        "--append",
+        "--append-only",
+        dest="append_only",
+        action="store_true",
+        help="Only adds the imports specified in --add-import if the file"
+        " contains existing imports.",
+    )
+    output_group.add_argument(
+        "--af",
+        "--force-adds",
+        dest="force_adds",
+        action="store_true",
+        help="Forces import adds even if the original file is empty.",
+    )
+    output_group.add_argument(
+        "--rm",
+        "--remove-import",
+        dest="remove_imports",
+        action="append",
+        help="Removes the specified import from all files.",
+    )
+    output_group.add_argument(
+        "--float-to-top",
+        dest="float_to_top",
+        action="store_true",
+        help="Causes all non-indented imports to float to the top of the file having its imports "
+        "sorted (immediately below the top of file comment).\n"
+        "This can be an excellent shortcut for collecting imports every once in a while "
+        "when you place them in the middle of a file to avoid context switching.\n\n"
+        "*NOTE*: It currently doesn't work with cimports and introduces some extra over-head "
+        "and a performance penalty.",
+    )
+    output_group.add_argument(
         "--ca",
         "--combine-as",
         dest="combine_as_imports",
         action="store_true",
         help="Combines as imports on the same line.",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--cs",
         "--combine-star",
         dest="combine_star",
@@ -264,69 +439,21 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Ensures that if a star import is present, "
         "nothing else is imported from that namespace.",
     )
-    parser.add_argument(
-        "-d",
-        "--stdout",
-        help="Force resulting output to stdout, instead of in-place.",
-        dest="write_to_stdout",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--df",
-        "--diff",
-        dest="show_diff",
-        action="store_true",
-        help="Prints a diff of all the changes isort would make to a file, instead of "
-        "changing it in place",
-    )
-    parser.add_argument(
-        "--ds",
-        "--no-sections",
-        help="Put all imports into the same section bucket",
-        dest="no_sections",
-        action="store_true",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "-e",
         "--balanced",
         dest="balanced_wrapping",
         action="store_true",
         help="Balances wrapping to produce the most consistent line length possible",
     )
-    parser.add_argument(
-        "-f",
-        "--future",
-        dest="known_future_library",
-        action="append",
-        help="Force isort to recognize a module as part of Python's internal future compatibility "
-        "libraries. WARNING: this overrides the behavior of __future__ handling and therefore"
-        " can result in code that can't execute. If you're looking to add dependencies such "
-        "as six a better option is to create a another section below --future using custom "
-        "sections. See: https://github.com/PyCQA/isort#custom-sections-and-ordering and the "
-        "discussion here: https://github.com/PyCQA/isort/issues/1463.",
-    )
-    parser.add_argument(
-        "--fas",
-        "--force-alphabetical-sort",
-        action="store_true",
-        dest="force_alphabetical_sort",
-        help="Force all imports to be sorted as a single section",
-    )
-    parser.add_argument(
-        "--fass",
-        "--force-alphabetical-sort-within-sections",
-        action="store_true",
-        dest="force_alphabetical_sort_within_sections",
-        help="Force all imports to be sorted alphabetically within a section",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "--ff",
         "--from-first",
         dest="from_first",
         help="Switches the typical ordering preference, "
         "showing from imports first then straight ones.",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--fgw",
         "--force-grid-wrap",
         nargs="?",
@@ -337,42 +464,34 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "to be grid wrapped regardless of line "
         "length. If 0 is passed in (the global default) only line length is considered.",
     )
-    parser.add_argument(
-        "--fss",
-        "--force-sort-within-sections",
-        action="store_true",
-        dest="force_sort_within_sections",
-        help="Don't sort straight-style imports (like import sys) before from-style imports "
-        "(like from itertools import groupby). Instead, sort the imports by module, "
-        "independent of import style.",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "-i",
         "--indent",
         help='String to place for indents defaults to "    " (4 spaces).',
         dest="indent",
         type=str,
     )
-    parser.add_argument(
-        "-j", "--jobs", help="Number of files to process in parallel.", dest="jobs", type=int
+    output_group.add_argument(
+        "--lai", "--lines-after-imports", dest="lines_after_imports", type=int
     )
-    parser.add_argument("--lai", "--lines-after-imports", dest="lines_after_imports", type=int)
-    parser.add_argument("--lbt", "--lines-between-types", dest="lines_between_types", type=int)
-    parser.add_argument(
+    output_group.add_argument(
+        "--lbt", "--lines-between-types", dest="lines_between_types", type=int
+    )
+    output_group.add_argument(
         "--le",
         "--line-ending",
         dest="line_ending",
         help="Forces line endings to the specified value. "
         "If not set, values will be guessed per-file.",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--ls",
         "--length-sort",
         help="Sort imports by their string length.",
         dest="length_sort",
         action="store_true",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--lss",
         "--length-sort-straight",
         help="Sort straight imports by their string length. Similar to `length_sort` "
@@ -380,7 +499,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="length_sort_straight",
         action="store_true",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "-m",
         "--multi-line",
         dest="multi_line_output",
@@ -392,7 +511,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "8-vertical-hanging-indent-bracket, 9-vertical-prefix-from-module-import, "
         "10-hanging-indent-with-parentheses).",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "-n",
         "--ensure-newline-before-comments",
         dest="ensure_newline_before_comments",
@@ -407,21 +526,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Leaves `from` imports with multiple imports 'as-is' "
         "(e.g. `from foo import a, c ,b`).",
     )
-    parser.add_argument(
-        "--nlb",
-        "--no-lines-before",
-        help="Sections which should not be split with previous by empty lines",
-        dest="no_lines_before",
-        action="append",
-    )
-    parser.add_argument(
-        "-o",
-        "--thirdparty",
-        dest="known_third_party",
-        action="append",
-        help="Force isort to recognize a module as being part of a third party library.",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "--ot",
         "--order-by-type",
         dest="order_by_type",
@@ -434,7 +539,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "likely will want to turn it off. From the CLI the `--dont-order-by-type` option will turn "
         "this off.",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--dt",
         "--dont-order-by-type",
         dest="dont_order_by_type",
@@ -447,68 +552,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         " or a related coding standard and has many imports this is a good default. You can turn "
         "this on from the CLI using `--order-by-type`.",
     )
-    parser.add_argument(
-        "-p",
-        "--project",
-        dest="known_first_party",
-        action="append",
-        help="Force isort to recognize a module as being part of the current python project.",
-    )
-    parser.add_argument(
-        "--known-local-folder",
-        dest="known_local_folder",
-        action="append",
-        help="Force isort to recognize a module as being a local folder. "
-        "Generally, this is reserved for relative imports (from . import module).",
-    )
-    parser.add_argument(
-        "-q",
-        "--quiet",
-        action="store_true",
-        dest="quiet",
-        help="Shows extra quiet output, only errors are outputted.",
-    )
-    parser.add_argument(
-        "--rm",
-        "--remove-import",
-        dest="remove_imports",
-        action="append",
-        help="Removes the specified import from all files.",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "--rr",
         "--reverse-relative",
         dest="reverse_relative",
         action="store_true",
         help="Reverse order of relative imports.",
-    )
-    parser.add_argument(
-        "-s",
-        "--skip",
-        help="Files that sort imports should skip over. If you want to skip multiple "
-        "files you should specify twice: --skip file1 --skip file2.",
-        dest="skip",
-        action="append",
-    )
-    parser.add_argument(
-        "--sd",
-        "--section-default",
-        dest="default_section",
-        help="Sets the default section for import options: " + str(sections.DEFAULT),
-    )
-    parser.add_argument(
-        "--sg",
-        "--skip-glob",
-        help="Files that sort imports should skip over.",
-        dest="skip_glob",
-        action="append",
-    )
-    parser.add_argument(
-        "--gitignore",
-        "--skip-gitignore",
-        action="store_true",
-        dest="skip_gitignore",
-        help="Treat project as a git repository and ignore files listed in .gitignore",
     )
     inline_args_group.add_argument(
         "--sl",
@@ -517,37 +566,21 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Forces all from imports to appear on their own line",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--nsl",
         "--single-line-exclusions",
         help="One or more modules to exclude from the single line rule.",
         dest="single_line_exclusions",
         action="append",
     )
-    parser.add_argument(
-        "--sp",
-        "--settings-path",
-        "--settings-file",
-        "--settings",
-        dest="settings_path",
-        help="Explicitly set the settings path or file instead of auto determining "
-        "based on file location.",
-    )
-    parser.add_argument(
-        "-t",
-        "--top",
-        help="Force specific imports to the top of their appropriate section.",
-        dest="force_to_top",
-        action="append",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "--tc",
         "--trailing-comma",
         dest="include_trailing_comma",
         action="store_true",
         help="Includes a trailing comma on multi line imports that include parentheses.",
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--up",
         "--use-parentheses",
         dest="use_parentheses",
@@ -556,38 +589,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         " **NOTE**: This is separate from wrap modes, and only affects how individual lines that "
         " are too long get continued, not sections of multiple imports.",
     )
-    parser.add_argument(
-        "-V",
-        "--version",
-        action="store_true",
-        dest="show_version",
-        help="Displays the currently installed version of isort.",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        dest="verbose",
-        help="Shows verbose output, such as when files are skipped or when a check is successful.",
-    )
-    parser.add_argument(
-        "--virtual-env",
-        dest="virtual_env",
-        help="Virtual environment to use for determining whether a package is third-party",
-    )
-    parser.add_argument(
-        "--conda-env",
-        dest="conda_env",
-        help="Conda environment to use for determining whether a package is third-party",
-    )
-    parser.add_argument(
-        "--vn",
-        "--version-number",
-        action="version",
-        version=__version__,
-        help="Returns just the current version number without the logo",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "-l",
         "-w",
         "--line-length",
@@ -596,7 +598,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="line_length",
         type=int,
     )
-    parser.add_argument(
+    output_group.add_argument(
         "--wl",
         "--wrap-length",
         dest="wrap_length",
@@ -604,30 +606,184 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Specifies how long lines that are wrapped should be, if not set line_length is used."
         "\nNOTE: wrap_length must be LOWER than or equal to line_length.",
     )
-    parser.add_argument(
-        "--ws",
-        "--ignore-whitespace",
-        action="store_true",
-        dest="ignore_whitespace",
-        help="Tells isort to ignore whitespace differences when --check-only is being used.",
-    )
-    parser.add_argument(
+    output_group.add_argument(
         "--case-sensitive",
         dest="case_sensitive",
         action="store_true",
         help="Tells isort to include casing when sorting module names",
     )
-    parser.add_argument(
-        "--filter-files",
-        dest="filter_files",
+    output_group.add_argument(
+        "--remove-redundant-aliases",
+        dest="remove_redundant_aliases",
         action="store_true",
-        help="Tells isort to filter files even when they are explicitly passed in as "
-        "part of the CLI command.",
+        help=(
+            "Tells isort to remove redundant aliases from imports, such as `import os as os`."
+            " This defaults to `False` simply because some projects use these seemingly useless "
+            " aliases to signify intent and change behaviour."
+        ),
     )
-    parser.add_argument(
-        "files", nargs="*", help="One or more Python source files that need their imports sorted."
+    output_group.add_argument(
+        "--honor-noqa",
+        dest="honor_noqa",
+        action="store_true",
+        help="Tells isort to honor noqa comments to enforce skipping those comments.",
     )
-    parser.add_argument(
+    output_group.add_argument(
+        "--treat-comment-as-code",
+        dest="treat_comments_as_code",
+        action="append",
+        help="Tells isort to treat the specified single line comment(s) as if they are code.",
+    )
+    output_group.add_argument(
+        "--treat-all-comment-as-code",
+        dest="treat_all_comments_as_code",
+        action="store_true",
+        help="Tells isort to treat all single line comments as if they are code.",
+    )
+    output_group.add_argument(
+        "--formatter",
+        dest="formatter",
+        type=str,
+        help="Specifies the name of a formatting plugin to use when producing output.",
+    )
+    output_group.add_argument(
+        "--color",
+        dest="color_output",
+        action="store_true",
+        help="Tells isort to use color in terminal output.",
+    )
+
+    section_group.add_argument(
+        "--sd",
+        "--section-default",
+        dest="default_section",
+        help="Sets the default section for import options: " + str(sections.DEFAULT),
+    )
+    section_group.add_argument(
+        "--only-sections",
+        "--os",
+        dest="only_sections",
+        action="store_true",
+        help="Causes imports to be sorted only based on their sections like STDLIB,THIRDPARTY etc. "
+        "Imports are unaltered and keep their relative positions within the different sections.",
+    )
+    section_group.add_argument(
+        "--ds",
+        "--no-sections",
+        help="Put all imports into the same section bucket",
+        dest="no_sections",
+        action="store_true",
+    )
+    section_group.add_argument(
+        "--fas",
+        "--force-alphabetical-sort",
+        action="store_true",
+        dest="force_alphabetical_sort",
+        help="Force all imports to be sorted as a single section",
+    )
+    section_group.add_argument(
+        "--fss",
+        "--force-sort-within-sections",
+        action="store_true",
+        dest="force_sort_within_sections",
+        help="Don't sort straight-style imports (like import sys) before from-style imports "
+        "(like from itertools import groupby). Instead, sort the imports by module, "
+        "independent of import style.",
+    )
+    section_group.add_argument(
+        "--fass",
+        "--force-alphabetical-sort-within-sections",
+        action="store_true",
+        dest="force_alphabetical_sort_within_sections",
+        help="Force all imports to be sorted alphabetically within a section",
+    )
+    section_group.add_argument(
+        "-t",
+        "--top",
+        help="Force specific imports to the top of their appropriate section.",
+        dest="force_to_top",
+        action="append",
+    )
+    section_group.add_argument(
+        "--combine-straight-imports",
+        "--csi",
+        dest="combine_straight_imports",
+        action="store_true",
+        help="Combines all the bare straight imports of the same section in a single line. "
+        "Won't work with sections which have 'as' imports",
+    )
+    section_group.add_argument(
+        "--nlb",
+        "--no-lines-before",
+        help="Sections which should not be split with previous by empty lines",
+        dest="no_lines_before",
+        action="append",
+    )
+    section_group.add_argument(
+        "--src",
+        "--src-path",
+        dest="src_paths",
+        action="append",
+        help="Add an explicitly defined source path "
+        "(modules within src paths have their imports automatically categorized as first_party).",
+    )
+    section_group.add_argument(
+        "-b",
+        "--builtin",
+        dest="known_standard_library",
+        action="append",
+        help="Force isort to recognize a module as part of Python's standard library.",
+    )
+    section_group.add_argument(
+        "--extra-builtin",
+        dest="extra_standard_library",
+        action="append",
+        help="Extra modules to be included in the list of ones in Python's standard library.",
+    )
+    section_group.add_argument(
+        "-f",
+        "--future",
+        dest="known_future_library",
+        action="append",
+        help="Force isort to recognize a module as part of Python's internal future compatibility "
+        "libraries. WARNING: this overrides the behavior of __future__ handling and therefore"
+        " can result in code that can't execute. If you're looking to add dependencies such "
+        "as six a better option is to create a another section below --future using custom "
+        "sections. See: https://github.com/PyCQA/isort#custom-sections-and-ordering and the "
+        "discussion here: https://github.com/PyCQA/isort/issues/1463.",
+    )
+    section_group.add_argument(
+        "-o",
+        "--thirdparty",
+        dest="known_third_party",
+        action="append",
+        help="Force isort to recognize a module as being part of a third party library.",
+    )
+    section_group.add_argument(
+        "-p",
+        "--project",
+        dest="known_first_party",
+        action="append",
+        help="Force isort to recognize a module as being part of the current python project.",
+    )
+    section_group.add_argument(
+        "--known-local-folder",
+        dest="known_local_folder",
+        action="append",
+        help="Force isort to recognize a module as being a local folder. "
+        "Generally, this is reserved for relative imports (from . import module).",
+    )
+    section_group.add_argument(
+        "--virtual-env",
+        dest="virtual_env",
+        help="Virtual environment to use for determining whether a package is third-party",
+    )
+    section_group.add_argument(
+        "--conda-env",
+        dest="conda_env",
+        help="Conda environment to use for determining whether a package is third-party",
+    )
+    section_group.add_argument(
         "--py",
         "--python-version",
         action="store",
@@ -639,169 +795,36 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "interpreter used to run isort "
         f"(currently: {sys.version_info.major}{sys.version_info.minor}) will be used.",
     )
-    parser.add_argument(
-        "--profile",
-        dest="profile",
-        type=str,
-        help="Base profile type to use for configuration. "
-        f"Profiles include: {', '.join(profiles.keys())}. As well as any shared profiles.",
-    )
-    parser.add_argument(
-        "--interactive",
-        dest="ask_to_apply",
-        action="store_true",
-        help="Tells isort to apply changes interactively.",
-    )
-    parser.add_argument(
-        "--old-finders",
-        "--magic-placement",
-        dest="old_finders",
-        action="store_true",
-        help="Use the old deprecated finder logic that relies on environment introspection magic.",
-    )
-    parser.add_argument(
-        "--show-config",
-        dest="show_config",
-        action="store_true",
-        help="See isort's determined config, as well as sources of config options.",
-    )
-    parser.add_argument(
-        "--show-files",
-        dest="show_files",
-        action="store_true",
-        help="See the files isort will be ran against with the current config options.",
-    )
-    parser.add_argument(
-        "--honor-noqa",
-        dest="honor_noqa",
-        action="store_true",
-        help="Tells isort to honor noqa comments to enforce skipping those comments.",
-    )
-    parser.add_argument(
-        "--remove-redundant-aliases",
-        dest="remove_redundant_aliases",
-        action="store_true",
-        help=(
-            "Tells isort to remove redundant aliases from imports, such as `import os as os`."
-            " This defaults to `False` simply because some projects use these seemingly useless "
-            " aliases to signify intent and change behaviour."
-        ),
-    )
-    parser.add_argument(
-        "--color",
-        dest="color_output",
-        action="store_true",
-        help="Tells isort to use color in terminal output.",
-    )
-    parser.add_argument(
-        "--float-to-top",
-        dest="float_to_top",
-        action="store_true",
-        help="Causes all non-indented imports to float to the top of the file having its imports "
-        "sorted (immediately below the top of file comment).\n"
-        "This can be an excellent shortcut for collecting imports every once in a while "
-        "when you place them in the middle of a file to avoid context switching.\n\n"
-        "*NOTE*: It currently doesn't work with cimports and introduces some extra over-head "
-        "and a performance penalty.",
-    )
-    parser.add_argument(
-        "--treat-comment-as-code",
-        dest="treat_comments_as_code",
-        action="append",
-        help="Tells isort to treat the specified single line comment(s) as if they are code.",
-    )
-    parser.add_argument(
-        "--treat-all-comment-as-code",
-        dest="treat_all_comments_as_code",
-        action="store_true",
-        help="Tells isort to treat all single line comments as if they are code.",
-    )
-    parser.add_argument(
-        "--formatter",
-        dest="formatter",
-        type=str,
-        help="Specifies the name of a formatting plugin to use when producing output.",
-    )
-    parser.add_argument(
-        "--ext",
-        "--extension",
-        "--supported-extension",
-        dest="supported_extensions",
-        action="append",
-        help="Specifies what extensions isort can be ran against.",
-    )
-    parser.add_argument(
-        "--blocked-extension",
-        dest="blocked_extensions",
-        action="append",
-        help="Specifies what extensions isort can never be ran against.",
-    )
-    parser.add_argument(
-        "--dedup-headings",
-        dest="dedup_headings",
-        action="store_true",
-        help="Tells isort to only show an identical custom import heading comment once, even if"
-        " there are multiple sections with the comment set.",
-    )
-    parser.add_argument(
-        "--only-sections",
-        "--os",
-        dest="only_sections",
-        action="store_true",
-        help="Causes imports to be sorted only based on their sections like STDLIB,THIRDPARTY etc. "
-        "Imports are unaltered and keep their relative positions within the different sections.",
-    )
-    parser.add_argument(
-        "--only-modified",
-        "--om",
-        dest="only_modified",
-        action="store_true",
-        help="Suppresses verbose output for non-modified files.",
-    )
-    parser.add_argument(
-        "--combine-straight-imports",
-        "--csi",
-        dest="combine_straight_imports",
-        action="store_true",
-        help="Combines all the bare straight imports of the same section in a single line. "
-        "Won't work with sections which have 'as' imports",
-    )
-    parser.add_argument(
-        "--dont-follow-links",
-        dest="dont_follow_links",
-        action="store_true",
-        help="Tells isort not to follow symlinks that are encountered when running recursively.",
-    )
 
     # deprecated options
-    parser.add_argument(
+    deprecated_group.add_argument(
         "--recursive",
         dest="deprecated_flags",
         action="append_const",
         const="--recursive",
         help=argparse.SUPPRESS,
     )
-    parser.add_argument(
+    deprecated_group.add_argument(
         "-rc", dest="deprecated_flags", action="append_const", const="-rc", help=argparse.SUPPRESS
     )
-    parser.add_argument(
+    deprecated_group.add_argument(
         "--dont-skip",
         dest="deprecated_flags",
         action="append_const",
         const="--dont-skip",
         help=argparse.SUPPRESS,
     )
-    parser.add_argument(
+    deprecated_group.add_argument(
         "-ns", dest="deprecated_flags", action="append_const", const="-ns", help=argparse.SUPPRESS
     )
-    parser.add_argument(
+    deprecated_group.add_argument(
         "--apply",
         dest="deprecated_flags",
         action="append_const",
         const="--apply",
         help=argparse.SUPPRESS,
     )
-    parser.add_argument(
+    deprecated_group.add_argument(
         "-k",
         "--keep-direct-and-as",
         dest="deprecated_flags",


### PR DESCRIPTION
Added these groups: 
- general
- target
- general output
- section output
- deprecated

Also moved arguments a bit because of new grouping.
Generated output: https://gist.github.com/infinityxxx/c4f8c6063e982d4f3bbe8e1a3a433c79

Closes https://github.com/PyCQA/isort/issues/880
