### PR TITLE
Profile: follow black behaviour with regard to gitignore

### DIFF
--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -8,6 +8,7 @@ black = {
     "use_parentheses": True,
     "ensure_newline_before_comments": True,
     "line_length": 88,
+    "skip_gitignore": True,
 }
 django = {
     "combine_as_imports": True,


### PR DESCRIPTION
Black for Python ignores the files listed in .gitignore.

Update the profile to follow that

Fixes #1585 