### PR TITLE
Implement custom output handling in sort_file

### DIFF
--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -873,6 +873,6 @@ def test_api_to_allow_custom_diff_and_output_stream_1583(capsys, tmpdir):
     assert "+import a" in isort_diff_content
     assert " import b" in isort_diff_content
     assert "-import a" in isort_diff_content
-    
+
     isort_output.seek(0)
-    assert isort_output.read() == "import a\nimport b\n"
+    assert isort_output.read().splitlines() == ["import a", "import b"]

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -869,7 +869,10 @@ def test_api_to_allow_custom_diff_and_output_stream_1583(capsys, tmpdir):
     assert not error
 
     isort_diff.seek(0)
-    assert "+import a\n import b\n-import a\n" in isort_diff.read()
-
+    isort_diff_content = isort_diff.read()
+    assert "+import a" in isort_diff_content
+    assert " import b" in isort_diff_content
+    assert "-import a" in isort_diff_content
+    
     isort_output.seek(0)
     assert isort_output.read() == "import a\nimport b\n"

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -848,3 +848,28 @@ def my_function():
     pass
 """
     )
+
+
+def test_api_to_allow_custom_diff_and_output_stream_1583(capsys, tmpdir):
+    """isort should provide a way from the Python API to process an existing
+    file and output to a stream the new version of that file, as well as a diff
+    to a different stream.
+    See: https://github.com/PyCQA/isort/issues/1583
+    """
+
+    tmp_file = tmpdir.join("file.py")
+    tmp_file.write("import b\nimport a\n")
+
+    isort_diff = StringIO()
+    isort_output = StringIO()
+
+    isort.file(tmp_file, show_diff=isort_diff, output=isort_output)
+
+    _, error = capsys.readouterr()
+    assert not error
+
+    isort_diff.seek(0)
+    assert "+import a\n import b\n-import a\n" in isort_diff.read()
+
+    isort_output.seek(0)
+    assert isort_output.read() == "import a\nimport b\n"


### PR DESCRIPTION
This will allow the following to be used:

    isort_diff = StringIO()
    isort_output = StringIO()
    isort.file("x.py",
               show_diff=isort_diff,
               output=isort_output)

Fixes #1583