### PR TITLE
Set pre-commit language_version to python3

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,6 @@
     entry: isort
     require_serial: true
     language: python
+    language_version: python3
     types: [python]
     args: ['--filter-files']


### PR DESCRIPTION
For details on how pre-commit chooses a default language version, see:
https://pre-commit.com/#overriding-language-version

> For each language, they default to using the system installed language

On some platforms this could be Python 2. As isort is Python-3-only,
this should be enforced in the pre-commit hook. As this isn't currently
listed, some projects have been forced to override it.