### PR TITLE
Add pyi and cython file support to .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,5 @@
     require_serial: true
     language: python
     language_version: python3
-    types: [python]
+    types_or: [cython, pyi, python]
     args: ['--filter-files']


### PR DESCRIPTION
Since pre-commit 2.9.0 (2020-11-21), the types_or key can be used to
match multiple disparate file types. For more upstream details, see:
https://github.com/pre-commit/pre-commit/issues/607