### PR TITLE
Put minimum pre-commit version in hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,3 +6,4 @@
     language_version: python3
     types_or: [cython, pyi, python]
     args: ['--filter-files']
+    minimum_pre_commit_version: '2.9.0'


### PR DESCRIPTION
(seeing as you're now using `types_or` - else the error messages people get may be a bit mysterious)