### PR TITLE
Specify the config file example corresponds to pyproject.toml

### DIFF
--- a/docs/configuration/black_compatibility.md
+++ b/docs/configuration/black_compatibility.md
@@ -11,6 +11,8 @@ All that's required to use isort alongside black is to set the isort profile to 
 For projects that officially use both isort and black, we recommend setting the black profile in a config file at the root of your project's repository.
 This way independent to how users call isort (pre-commit, CLI, or editor integration) the black profile will automatically be applied.
 
+For instance, your _pyproject.toml_ file would look something like
+
 ```ini
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
In reference to https://github.com/PyCQA/isort/issues/1617.
- [x] Explicitly mention that the example described refers to a pyproject.toml file.  