### PR TITLE
Update indent option doc

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -263,10 +263,10 @@ multi_line_output = 3
 
 ## Indent
 
-String to place for indents defaults to "    " (4 spaces).
+String to place for indents defaults to "&nbsp;&nbsp;&nbsp;&nbsp;" (4 spaces).
 
 **Type:** String  
-**Default:** `    `  
+**Default:** <code>&nbsp;&nbsp;&nbsp;&nbsp;</code>  
 **Python & Config File Name:** indent  
 **CLI Flags:**
 


### PR DESCRIPTION
The current rendering of the `indent` option documentation is a bit off:

![image](https://user-images.githubusercontent.com/553208/103368808-d147f280-4ac8-11eb-8207-d0519c62fd85.png)

This PR tries to improve things by using `<code>` and `&nbsp;`.
It renders correctly when viewing the `options.md` file on GitHub so I expect it's going to render correctly when visiting https://pycqa.github.io/isort/docs/configuration/options/#indent

Hope that helps