### PR TITLE
Make force_sort_within_sections respect case

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -668,6 +668,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "independent of import style.",
     )
     section_group.add_argument(
+        "--hcss",
+        "--honor-case-in-force-sorted-sections",
+        action="store_true",
+        dest="honor_case_in_force_sorted_sections",
+        help="Honor `--case-sensitive` when `--force-sort-within-sections` is being used. "
+        "Without this option set, `--order-by-type` decides module name ordering too.",
+    )
+    section_group.add_argument(
         "--fass",
         "--force-alphabetical-sort-within-sections",
         action="store_true",

--- a/isort/output.py
+++ b/isort/output.py
@@ -96,6 +96,7 @@ def sorted_imports(
                 new_section_output,
                 key=partial(
                     sorting.section_key,
+                    case_sensitive=config.case_sensitive,
                     order_by_type=config.order_by_type,
                     force_to_top=config.force_to_top,
                     lexicographical=config.lexicographical,

--- a/isort/output.py
+++ b/isort/output.py
@@ -97,6 +97,7 @@ def sorted_imports(
                 key=partial(
                     sorting.section_key,
                     case_sensitive=config.case_sensitive,
+                    honor_case_in_force_sorted_sections=config.honor_case_in_force_sorted_sections,
                     order_by_type=config.order_by_type,
                     force_to_top=config.force_to_top,
                     lexicographical=config.lexicographical,

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -206,6 +206,7 @@ class _Config:
     follow_links: bool = True
     dedupe_imports: bool = True
     indented_import_headings: bool = True
+    honor_case_in_force_sorted_sections: bool = False
 
     def __post_init__(self):
         py_version = self.py_version

--- a/isort/sorting.py
+++ b/isort/sorting.py
@@ -54,6 +54,7 @@ def module_key(
 def section_key(
     line: str,
     case_sensitive: bool,
+    honor_case_in_force_sorted_sections: bool,
     order_by_type: bool,
     force_to_top: List[str],
     lexicographical: bool = False,
@@ -77,7 +78,11 @@ def section_key(
         line = re.sub("^import ", "", line)
     if line.split(" ")[0] in force_to_top:
         section = "A"
-    if not case_sensitive or not order_by_type:
+    # * If honor_case_in_force_sorted_sections is true, and case_sensitive and
+    #   order_by_type are different, only ignore case in part of the line.
+    # * Otherwise, let order_by_type decide the sorting of the whole line. This
+    #   is only "correct" if case_sensitive and order_by_type have the same value.
+    if honor_case_in_force_sorted_sections and case_sensitive != order_by_type:
         split_module = line.split(" import ", 1)
         if len(split_module) > 1:
             module_name, names = split_module
@@ -88,6 +93,8 @@ def section_key(
             line = " import ".join([module_name, names])
         elif not case_sensitive:
             line = line.lower()
+    elif not order_by_type:
+        line = line.lower()
 
     return f"{section}{len(line) if length_sort else ''}{line}"
 

--- a/isort/sorting.py
+++ b/isort/sorting.py
@@ -53,6 +53,7 @@ def module_key(
 
 def section_key(
     line: str,
+    case_sensitive: bool,
     order_by_type: bool,
     force_to_top: List[str],
     lexicographical: bool = False,
@@ -76,8 +77,17 @@ def section_key(
         line = re.sub("^import ", "", line)
     if line.split(" ")[0] in force_to_top:
         section = "A"
-    if not order_by_type:
-        line = line.lower()
+    if not case_sensitive or not order_by_type:
+        split_module = line.split(" import ", 1)
+        if len(split_module) > 1:
+            module_name, names = split_module
+            if not case_sensitive:
+                module_name = module_name.lower()
+            if not order_by_type:
+                names = names.lower()
+            line = " import ".join([module_name, names])
+        elif not case_sensitive:
+            line = line.lower()
 
     return f"{section}{len(line) if length_sort else ''}{line}"
 

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -2358,10 +2358,10 @@ def test_alphabetic_sorting_no_newlines() -> None:
 def test_sort_within_section() -> None:
     """Test to ensure its possible to force isort to sort within sections"""
     test_input = (
+        "from Foob import ar\n"
         "import foo\n"
         "from foo import bar\n"
         "from foo.bar import Quux, baz\n"
-        "from Foob import ar\n"
     )
     test_output = isort.code(test_input, force_sort_within_sections=True)
     assert test_output == test_input
@@ -2382,11 +2382,11 @@ def test_sort_within_section() -> None:
     assert test_output == test_input
 
     test_input = (
-        "from Foob import ar\n"
         "import foo\n"
         "from foo import bar\n"
         "from foo.bar import baz\n"
         "from foo.bar import Quux\n"
+        "from Foob import ar\n"
     )
     test_output = isort.code(
         code=test_input,
@@ -2404,6 +2404,66 @@ def test_sort_within_section() -> None:
         code=test_input,
         case_sensitive=True,
         force_sort_within_sections=True,
+        order_by_type=True,
+        force_single_line=True,
+    )
+    assert test_output == test_input
+
+
+def test_sort_within_section_case_honored() -> None:
+    """Ensure isort can do partial case-sensitive sorting in force-sorted sections"""
+    test_input = (
+        "import foo\n"
+        "from foo import bar\n"
+        "from foo.bar import Quux, baz\n"
+        "from Foob import ar\n"
+    )
+    test_output = isort.code(
+        test_input, force_sort_within_sections=True, honor_case_in_force_sorted_sections=True
+    )
+    assert test_output == test_input
+
+    test_input = (
+        "import foo\n"
+        "from foo import bar\n"
+        "from foo.bar import baz\n"
+        "from foo.bar import Quux\n"
+        "from Foob import ar\n"
+    )
+    test_output = isort.code(
+        code=test_input,
+        force_sort_within_sections=True,
+        honor_case_in_force_sorted_sections=True,
+        order_by_type=False,
+        force_single_line=True,
+    )
+    assert test_output == test_input
+
+    test_input = (
+        "from Foob import ar\n"
+        "import foo\n"
+        "from foo import bar\n"
+        "from foo.bar import baz\n"
+        "from foo.bar import Quux\n"
+    )
+    test_output = isort.code(
+        code=test_input,
+        case_sensitive=True,
+        force_sort_within_sections=True,
+        honor_case_in_force_sorted_sections=True,
+        order_by_type=False,
+        force_single_line=True,
+    )
+    assert test_output == test_input
+
+    test_input = (
+        "from Foob import ar\n" "import foo\n" "from foo import Quux\n" "from foo import baz\n"
+    )
+    test_output = isort.code(
+        code=test_input,
+        case_sensitive=True,
+        force_sort_within_sections=True,
+        honor_case_in_force_sorted_sections=True,
         order_by_type=True,
         force_single_line=True,
     )

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -2358,10 +2358,10 @@ def test_alphabetic_sorting_no_newlines() -> None:
 def test_sort_within_section() -> None:
     """Test to ensure its possible to force isort to sort within sections"""
     test_input = (
-        "from Foob import ar\n"
         "import foo\n"
         "from foo import bar\n"
         "from foo.bar import Quux, baz\n"
+        "from Foob import ar\n"
     )
     test_output = isort.code(test_input, force_sort_within_sections=True)
     assert test_output == test_input
@@ -2377,6 +2377,34 @@ def test_sort_within_section() -> None:
         code=test_input,
         force_sort_within_sections=True,
         order_by_type=False,
+        force_single_line=True,
+    )
+    assert test_output == test_input
+
+    test_input = (
+        "from Foob import ar\n"
+        "import foo\n"
+        "from foo import bar\n"
+        "from foo.bar import baz\n"
+        "from foo.bar import Quux\n"
+    )
+    test_output = isort.code(
+        code=test_input,
+        case_sensitive=True,
+        force_sort_within_sections=True,
+        order_by_type=False,
+        force_single_line=True,
+    )
+    assert test_output == test_input
+
+    test_input = (
+        "from Foob import ar\n" "import foo\n" "from foo import Quux\n" "from foo import baz\n"
+    )
+    test_output = isort.code(
+        code=test_input,
+        case_sensitive=True,
+        force_sort_within_sections=True,
+        order_by_type=True,
         force_single_line=True,
     )
     assert test_output == test_input


### PR DESCRIPTION
force_sort_within_sections only looked at the order_by_type
option to determine how to order imports with different case
in a section. Whether you order import names by type or not
also affected the order of the modules.

When force_sort_within_sections is used:
* ignore case on the module name if case_sensitive is false,
* ignore case on the imported names if order_by_type is false.