### PR TITLE
Count trailing chars correctly in vertical grid multi line modes

### DIFF
--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -201,9 +201,11 @@ def _vertical_grid_common(need_trailing_char: bool, **interface):
         next_import = interface["imports"].pop(0)
         next_statement = f"{interface['statement']}, {next_import}"
         current_line_length = len(next_statement.split(interface["line_separator"])[-1])
-        if interface["imports"] or need_trailing_char:
-            # If we have more interface["imports"] we need to account for a comma after this import
-            # We might also need to account for a closing ) we're going to add.
+        if interface["imports"] or interface["include_trailing_comma"]:
+            # We need to account for a comma after this import.
+            current_line_length += 1
+        if not interface["imports"] and need_trailing_char:
+            # We need to account for a closing ) we're going to add.
             current_line_length += 1
         if current_line_length > interface["line_length"]:
             next_statement = (
@@ -224,7 +226,7 @@ def vertical_grid(**interface) -> str:
 @_wrap_mode
 def vertical_grid_grouped(**interface):
     return (
-        _vertical_grid_common(need_trailing_char=True, **interface)
+        _vertical_grid_common(need_trailing_char=False, **interface)
         + interface["line_separator"]
         + ")"
     )


### PR DESCRIPTION
Partial fix for issue #1634 

I've run the tests and they pass, but this probably needs a few new unit tests.

This also effectively makes multi-line wrapping modes 5-vert-grid-grouped and 6-vert-grid-grouped-no-comma the same. I'm not sure if/how that should be documented.