### PR TITLE
Sort relative imports correctly with force_sort_within_sections

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -669,6 +669,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "Without this option set, `--order-by-type` decides module name ordering too.",
     )
     section_group.add_argument(
+        "--srss",
+        "--sort-relative-in-force-sorted-sections",
+        action="store_true",
+        dest="sort_relative_in_force_sorted_sections",
+        help="When using `--force-sort-within-sections`, sort relative imports the same "
+        "way as they are sorted when not using that setting.",
+    )
+    section_group.add_argument(
         "--fass",
         "--force-alphabetical-sort-within-sections",
         action="store_true",

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -206,6 +206,7 @@ class _Config:
     follow_links: bool = True
     indented_import_headings: bool = True
     honor_case_in_force_sorted_sections: bool = False
+    sort_relative_in_force_sorted_sections: bool = False
 
     def __post_init__(self):
         py_version = self.py_version

--- a/isort/sorting.py
+++ b/isort/sorting.py
@@ -54,6 +54,14 @@ def module_key(
 def section_key(line: str, config: Config) -> str:
     section = "B"
 
+    if (
+        not config.sort_relative_in_force_sorted_sections
+        and config.reverse_relative
+        and line.startswith("from .")
+    ):
+        match = re.match(r"^from (\.+)\s*(.*)", line)
+        if match:  # pragma: no cover - regex always matches if line starts with "from ."
+            line = f"from {' '.join(match.groups())}"
     if config.group_by_package and line.strip().startswith("from"):
         line = line.split(" import", 1)[0]
 
@@ -62,8 +70,9 @@ def section_key(line: str, config: Config) -> str:
     else:
         line = re.sub("^from ", "", line)
         line = re.sub("^import ", "", line)
-    sep = " " if config.reverse_relative else "_"
-    line = re.sub(r"^(\.+)", fr"\1{sep}", line)
+    if config.sort_relative_in_force_sorted_sections:
+        sep = " " if config.reverse_relative else "_"
+        line = re.sub(r"^(\.+)", fr"\1{sep}", line)
     if line.split(" ")[0] in config.force_to_top:
         section = "A"
     # * If honor_case_in_force_sorted_sections is true, and case_sensitive and

--- a/isort/sorting.py
+++ b/isort/sorting.py
@@ -54,10 +54,6 @@ def module_key(
 def section_key(line: str, config: Config) -> str:
     section = "B"
 
-    if config.reverse_relative and line.startswith("from ."):
-        match = re.match(r"^from (\.+)\s*(.*)", line)
-        if match:  # pragma: no cover - regex always matches if line starts with "from ."
-            line = f"from {' '.join(match.groups())}"
     if config.group_by_package and line.strip().startswith("from"):
         line = line.split(" import", 1)[0]
 
@@ -66,6 +62,8 @@ def section_key(line: str, config: Config) -> str:
     else:
         line = re.sub("^from ", "", line)
         line = re.sub("^import ", "", line)
+    sep = " " if config.reverse_relative else "_"
+    line = re.sub(r"^(\.+)", fr"\1{sep}", line)
     if line.split(" ")[0] in config.force_to_top:
         section = "A"
     # * If honor_case_in_force_sorted_sections is true, and case_sensitive and

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -2914,7 +2914,40 @@ def test_sort_within_sections_with_force_to_top_issue_473() -> None:
     )
 
 
-def test_force_sort_within_sections_with_relative_imports_issue_1659() -> None:
+def test_force_sort_within_sections_with_relative_imports() -> None:
+    """Test sorting of relative imports with force_sort_within_sections=True"""
+    assert isort.check_code(
+        """import .
+from . import foo
+from .. import a
+from ..alpha.beta import b
+from ..omega import c
+import .apple as bar
+from .mango import baz
+""",
+        show_diff=True,
+        force_sort_within_sections=True,
+    )
+
+
+def test_force_sort_within_sections_with_reverse_relative_imports() -> None:
+    """Test reverse sorting of relative imports with force_sort_within_sections=True"""
+    assert isort.check_code(
+        """import .
+from . import foo
+from .mango import baz
+from ..alpha.beta import b
+from .. import a
+from ..omega import c
+import .apple as bar
+""",
+        show_diff=True,
+        force_sort_within_sections=True,
+        reverse_relative=True,
+    )
+
+
+def test_sort_relative_in_force_sorted_sections_issue_1659() -> None:
     """Ensure relative imports are sorted within sections"""
     assert isort.check_code(
         """from .. import a
@@ -2927,10 +2960,11 @@ from .mango import baz
 """,
         show_diff=True,
         force_sort_within_sections=True,
+        sort_relative_in_force_sorted_sections=True,
     )
 
 
-def test_force_sort_within_sections_with_reverse_relative_imports_issue_1659() -> None:
+def test_reverse_sort_relative_in_force_sorted_sections_issue_1659() -> None:
     """Ensure reverse ordered relative imports are sorted within sections"""
     assert isort.check_code(
         """import .
@@ -2943,6 +2977,7 @@ from ..omega import c
 """,
         show_diff=True,
         force_sort_within_sections=True,
+        sort_relative_in_force_sorted_sections=True,
         reverse_relative=True,
     )
 

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -2914,6 +2914,39 @@ def test_sort_within_sections_with_force_to_top_issue_473() -> None:
     )
 
 
+def test_force_sort_within_sections_with_relative_imports_issue_1659() -> None:
+    """Ensure relative imports are sorted within sections"""
+    assert isort.check_code(
+        """from .. import a
+from ..alpha.beta import b
+from ..omega import c
+import .
+from . import foo
+import .apple as bar
+from .mango import baz
+""",
+        show_diff=True,
+        force_sort_within_sections=True,
+    )
+
+
+def test_force_sort_within_sections_with_reverse_relative_imports_issue_1659() -> None:
+    """Ensure reverse ordered relative imports are sorted within sections"""
+    assert isort.check_code(
+        """import .
+from . import foo
+import .apple as bar
+from .mango import baz
+from .. import a
+from ..alpha.beta import b
+from ..omega import c
+""",
+        show_diff=True,
+        force_sort_within_sections=True,
+        reverse_relative=True,
+    )
+
+
 def test_correct_number_of_new_lines_with_comment_issue_435() -> None:
     """Test to ensure that injecting a comment in-between imports
     doesn't mess up the new line spacing

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -331,18 +331,18 @@ from . import foo
     assert (
         isort.code(
             """
-from .. import foo
-# Comment canary
 from . import foo
+# Comment canary
+from .. import foo
 """,
             ensure_newline_before_comments=True,
             force_sort_within_sections=True,
         )
         == """
-from .. import foo
+from . import foo
 
 # Comment canary
-from . import foo
+from .. import foo
 """
     )
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -331,18 +331,18 @@ from . import foo
     assert (
         isort.code(
             """
-from . import foo
-# Comment canary
 from .. import foo
+# Comment canary
+from . import foo
 """,
             ensure_newline_before_comments=True,
             force_sort_within_sections=True,
         )
         == """
-from . import foo
+from .. import foo
 
 # Comment canary
-from .. import foo
+from . import foo
 """
     )
 


### PR DESCRIPTION
Relative import sort order when using force_sort_within_sections
was inconsistent with the order without that setting. Change the
force_sort_within_sections sort order to match.

This fixes the relative import ordering issues noted in #1659.

Even though all the existing tests still pass (with only one minor test change), the change to the ordering might be significant enough that this needs to be hidden behind a new setting until 6.x?