### PR TITLE
Fix not replacing the source file if only literals are changed

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -125,17 +125,22 @@ def process(
                 line_separator = "\n"
 
             if code_sorting and code_sorting_section:
-                output_stream.write(
-                    textwrap.indent(
-                        isort.literal.assignment(
-                            code_sorting_section,
-                            str(code_sorting),
-                            extension,
-                            config=_indented_config(config, indent),
-                        ),
-                        code_sorting_indent,
-                    )
+                sorted_code = textwrap.indent(
+                    isort.literal.assignment(
+                        code_sorting_section,
+                        str(code_sorting),
+                        extension,
+                        config=_indented_config(config, indent),
+                    ),
+                    code_sorting_indent,
                 )
+                made_changes = made_changes or _has_changed(
+                    before=code_sorting_section,
+                    after=sorted_code,
+                    line_separator=line_separator,
+                    ignore_whitespace=config.ignore_whitespace,
+                )
+                output_stream.write(sorted_code)
         else:
             stripped_line = line.strip()
             if stripped_line and not line_separator:
@@ -198,17 +203,22 @@ def process(
                     not_imports = True
                 elif code_sorting:
                     if not stripped_line:
-                        output_stream.write(
-                            textwrap.indent(
-                                isort.literal.assignment(
-                                    code_sorting_section,
-                                    str(code_sorting),
-                                    extension,
-                                    config=_indented_config(config, indent),
-                                ),
-                                code_sorting_indent,
-                            )
+                        sorted_code = textwrap.indent(
+                            isort.literal.assignment(
+                                code_sorting_section,
+                                str(code_sorting),
+                                extension,
+                                config=_indented_config(config, indent),
+                            ),
+                            code_sorting_indent,
                         )
+                        made_changes = made_changes or _has_changed(
+                            before=code_sorting_section,
+                            after=sorted_code,
+                            line_separator=line_separator,
+                            ignore_whitespace=config.ignore_whitespace,
+                        )
+                        output_stream.write(sorted_code)
                         not_imports = True
                         code_sorting = False
                         code_sorting_section = ""

--- a/isort/core.py
+++ b/isort/core.py
@@ -159,10 +159,11 @@ def process(
                 and stripped_line not in config.section_comments
             ):
                 in_top_comment = True
-            elif in_top_comment:
-                if not line.startswith("#") or stripped_line in config.section_comments:
-                    in_top_comment = False
-                    first_comment_index_end = index - 1
+            elif in_top_comment and (
+                not line.startswith("#") or stripped_line in config.section_comments
+            ):
+                in_top_comment = False
+                first_comment_index_end = index - 1
 
             was_in_quote = bool(in_quote)
             if (not stripped_line.startswith("#") or in_quote) and '"' in line or "'" in line:

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -7,7 +7,7 @@ from io import StringIO
 import pytest
 
 import isort
-from isort import Config, exceptions
+from isort import Config, api, exceptions
 
 
 def test_semicolon_ignored_for_dynamic_lines_after_import_issue_1178():
@@ -482,6 +482,43 @@ d = 1
 
 # isort: dict
 y = {"b": "c", "z": "z"}"""
+    )
+    assert api.sort_stream(
+        input_stream=StringIO(
+            """
+import a
+import x
+
+# isort: list
+__all__ = ["b", "a", "b"]
+
+# isort: unique-list
+__all__ = ["b", "a", "b"]
+
+# isort: tuple
+__all__ = ("b", "a", "b")
+
+# isort: unique-tuple
+__all__ = ("b", "a", "b")
+
+# isort: set
+__all__ = {"b", "a", "b"}
+
+
+def method():
+    # isort: list
+    x = ["b", "a"]
+
+
+# isort: assignments
+d = 1
+b = 2
+a = 3
+
+# isort: dict
+y = {"z": "z", "b": "b", "b": "c"}""",
+        ),
+        output_stream=StringIO(),
     )
 
 


### PR DESCRIPTION
When there is no change to the imports but the literal are changed (i.e. sorted by isort), isort doesn't replace the source file with the sorted file. This pull request fixes the problem.