### PR TITLE
fix :Failed to pull configuration information from pyproject.toml

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -647,7 +647,7 @@ def _find_config(path: str) -> Tuple[str, Dict[str, Any]]:
 def _get_config_data(file_path: str, sections: Tuple[str]) -> Dict[str, Any]:
     settings: Dict[str, Any] = {}
 
-    with open(file_path) as config_file:
+    with open(file_path, encoding="utf-8") as config_file:
         if file_path.endswith(".toml"):
             config = toml.load(config_file)
             for section in sections:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -189,6 +189,31 @@ def test_editorconfig_without_sections(tmpdir):
     assert not loaded_settings
 
 
+def test_get_config_data_with_toml_and_utf8(tmpdir):
+    test_config = tmpdir.join("pyproject.toml")
+    # Exception: UnicodeDecodeError: 'gbk' codec can't decode byte 0x84 in position 57
+    test_config.write_text(
+        """
+[tool.poetry]
+
+description = "基于FastAPI + Mysql的 TodoList"  # Exception: UnicodeDecodeError
+name = "TodoList"
+version = "0.1.0"
+
+[tool.isort]
+
+multi_line_output = 3
+
+""",
+        "utf8",
+    )
+    loaded_settings = settings._get_config_data(
+        str(test_config), sections=settings.CONFIG_SECTIONS["pyproject.toml"]
+    )
+    assert loaded_settings
+    assert str(tmpdir) in loaded_settings["source"]
+
+
 def test_as_bool():
     assert settings._as_bool("TrUe") is True
     assert settings._as_bool("true") is True


### PR DESCRIPTION
When I configured isort in the `pyproject.toml`, an error occurred: `Failed to pull configuration information from pyproject.toml`.

After further analysis, it is because pyproject.toml contains many non-ASCII characters, which causes the system default encoding to fail to open.
This pull request added a test case to reproduce the problem and fixes it.