### PR TITLE
Clarify documentation for --skip option

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -314,7 +314,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Files that sort imports should skip over. If you want to skip multiple "
         "files you should specify twice: --skip file1 --skip file2. Values can be ",
         "file names, directory names or file paths. To skip all files in a nested path "
-        "use --skip-glob."
+        "use --skip-glob.",
         dest="skip",
         action="append",
     )

--- a/isort/main.py
+++ b/isort/main.py
@@ -312,7 +312,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "-s",
         "--skip",
         help="Files that sort imports should skip over. If you want to skip multiple "
-        "files you should specify twice: --skip file1 --skip file2. Values can be ",
+        "files you should specify twice: --skip file1 --skip file2. Values can be "
         "file names, directory names or file paths. To skip all files in a nested path "
         "use --skip-glob.",
         dest="skip",

--- a/isort/main.py
+++ b/isort/main.py
@@ -312,7 +312,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "-s",
         "--skip",
         help="Files that sort imports should skip over. If you want to skip multiple "
-        "files you should specify twice: --skip file1 --skip file2.",
+        "files you should specify twice: --skip file1 --skip file2. Values can be ",
+        "file names, directory names or file paths. To skip all files in a nested path "
+        "use --skip-glob."
         dest="skip",
         action="append",
     )


### PR DESCRIPTION
The --skip option only handles full file paths or names of
individual path components.

For example, "foo/bar/baz.py" can be used to skip just that file.
And "foo" would skip any files with that name and any files nested
in directories with that name.

On the other hand, "foo/bar" does *not* skip everything in the
"foo/bar" directory. --skip-glob can be used to achieve this.

Attempt to clarify the documentation to say that.

Potential fix for #1685. Alternative to #1690.