### PR TITLE
Support paths to directories as arguments to --skip

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -522,9 +522,9 @@ class Config(_Config):
             normalized_path = normalized_path[2:]
 
         for skip_path in self.skip:
-            if posixpath.abspath(normalized_path) == posixpath.abspath(
-                skip_path.replace("\\", "/")
-            ):
+            skip_abspath = posixpath.abspath(skip_path.replace("\\", "/"))
+            file_abspath = posixpath.abspath(normalized_path)
+            if posixpath.commonpath([file_abspath, skip_abspath]) == skip_abspath:
                 return True
 
         position = os.path.split(file_name)


### PR DESCRIPTION
The --skip option can handle a file path like "foo/bar.py" to
skip just that file, but did not handle a directory path like
"foo/bar" to skip all files in that directory.

Add support for that.

Potential fix for #1685. Alternative to #1689.