### PR TITLE
Fix --gitignore flag not working on relative subdir files

### DIFF
--- a/isort/files.py
+++ b/isort/files.py
@@ -34,7 +34,7 @@ def find(
                 for filename in filenames:
                     filepath = os.path.join(dirpath, filename)
                     if config.is_supported_filetype(filepath):
-                        if config.is_skipped(Path(filepath)):
+                        if config.is_skipped(Path(os.path.abspath(filepath))):
                             skipped.append(filename)
                         else:
                             yield filepath


### PR DESCRIPTION
Hi,

I found a bug regarding the `--gitignore` CLI flag.
When a file is ignored in .gitignore and you use a relative path, this file won't be skipped.

For example, if I have a file `nested_dir/has_imports.py` in my .gitignore, doing :
```bash
isort . --gitignore
```
will fix `nested_dir/has_imports.py`. Meanwhile :
```bash
isort $(pwd) --gitignore
```
will skip it, as intended.

This PR fixes this by always using an absolute import when checking if a file has to be skipped.