### PR TITLE
Faster gitignore

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -520,7 +520,7 @@ class Config(_Config):
             files = glob.glob(str(git_folder) + "/**/*", recursive=True)
             files_result = (
                 subprocess.check_output(  # nosec # skipcq: PYL-W1510
-                    ["git", "-C", git_folder, "check-ignore", *files]
+                    ["git", "-C", str(git_folder), "check-ignore", *files]
                 )
                 .decode("utf-8")
                 .split("\n")

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -520,7 +520,7 @@ class Config(_Config):
 
             files = glob.glob(str(git_folder) + "/**/*", recursive=True)
             files_result = (
-                codecs.escape_decode(
+                codecs.escape_decode(  # type: ignore
                     subprocess.check_output(  # nosec # skipcq: PYL-W1510
                         ["git", "-C", str(git_folder), "check-ignore", *files]
                     )

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -2,6 +2,7 @@
 
 Defines how the default settings for isort should be loaded
 """
+import codecs
 import configparser
 import fnmatch
 import glob
@@ -519,15 +520,17 @@ class Config(_Config):
 
             files = glob.glob(str(git_folder) + "/**/*", recursive=True)
             files_result = (
-                subprocess.check_output(  # nosec # skipcq: PYL-W1510
-                    ["git", "-C", str(git_folder), "check-ignore", *files]
-                )
+                codecs.escape_decode(
+                    subprocess.check_output(  # nosec # skipcq: PYL-W1510
+                        ["git", "-C", str(git_folder), "check-ignore", *files]
+                    )
+                )[0]
                 .decode("utf-8")
                 .split("\n")
             )
             files_result = files_result[:-1] if files_result else files_result
 
-            self.git_ignore[git_folder] = {Path(f) for f in files_result}
+            self.git_ignore[git_folder] = {Path(f.strip('"')) for f in files_result}
 
             return git_folder
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1123,17 +1123,20 @@ nested_dir_ignored
     git_project1.mkdir("nested_dir_ignored").join("has_imports.py").write(import_content)
 
     should_check = [
-        "has_imports.py",
-        "nested_dir/has_imports.py",
-        "git_project0/has_imports.py",
-        "git_project1/has_imports.py",
-        "git_project1/nested_dir/has_imports.py",
+        "/has_imports.py",
+        "/nested_dir/has_imports.py",
+        "/git_project0/has_imports.py",
+        "/git_project1/has_imports.py",
+        "/git_project1/nested_dir/has_imports.py",
     ]
 
     out, error = main_check([str(tmpdir), "--skip-gitignore", "--filter-files", "--check"])
 
-    assert all(f"{str(tmpdir)}/{file}" in error for file in should_check)
+    if os.name == "nt":
+        should_check = [sc.replace("/", "\\") for sc in should_check]
+
+    assert all(f"{str(tmpdir)}{file}" in error for file in should_check)
 
     out, error = main_check([str(tmpdir), "--skip-gitignore", "--filter-files"])
 
-    assert all(f"{str(tmpdir)}/{file}" in out for file in should_check)
+    assert all(f"{str(tmpdir)}{file}" in out for file in should_check)


### PR DESCRIPTION
This PR addresses #1628 
The method I used is to keep in memory every gitignored files of checked folders. This reduces ``git -check-ignore`` calls which should be enough to improve significantly the ``--gitignore`` speed.
For now I haven't really tested it and there's room for optimization.

Let me know if you agree with the concept.