### PR TITLE
Issue/1705/stream/skip failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Find out more about isort's release policy [here](https://pycqa.github.io/isort/
 ### 5.9.0 TBD
   - Fixed (https://github.com/PyCQA/isort/pull/1695) added imports being added to doc string in some cases.
   - Implemented #1697: Provisional support for PEP 582: skip `__pypackages__` directories by default.
+  - Implemented #1705: More intuitive handling of isort:skip_file comments on streams.
 
 ### 5.8.0 March 20th 2021
   - Fixed #1631: as import comments can in some cases be duplicated.

--- a/isort/api.py
+++ b/isort/api.py
@@ -125,6 +125,7 @@ def sort_stream(
     file_path: Optional[Path] = None,
     disregard_skip: bool = False,
     show_diff: Union[bool, TextIO] = False,
+    raise_on_skip: bool = True,
     **config_kwargs,
 ) -> bool:
     """Sorts any imports within the provided code stream, outputs to the provided output stream.
@@ -150,6 +151,7 @@ def sort_stream(
             config=config,
             file_path=file_path,
             disregard_skip=disregard_skip,
+            raise_on_skip=raise_on_skip,
             **config_kwargs,
         )
         _output_stream.seek(0)
@@ -187,6 +189,7 @@ def sort_stream(
             _internal_output,
             extension=extension or (file_path and file_path.suffix.lstrip(".")) or "py",
             config=config,
+            raise_on_skip=raise_on_skip,
         )
     except FileSkipComment:
         raise FileSkipComment(content_source)

--- a/isort/core.py
+++ b/isort/core.py
@@ -153,9 +153,8 @@ def process(
                 if file_skip_comment in line:
                     if raise_on_skip:
                         raise FileSkipComment("Passed in content")
-                    else:
-                        isort_off = True
-                        skip_file = True
+                    isort_off = True
+                    skip_file = True
 
             if not in_quote and stripped_line == "# isort: off":
                 isort_off = True

--- a/isort/exceptions.py
+++ b/isort/exceptions.py
@@ -56,7 +56,7 @@ class FileSkipComment(FileSkipped):
 
     def __init__(self, file_path: str):
         super().__init__(
-            f"{file_path} contains an file skip comment and was skipped.", file_path=file_path
+            f"{file_path} contains a file skip comment and was skipped.", file_path=file_path
         )
 
 

--- a/isort/hooks.py
+++ b/isort/hooks.py
@@ -53,7 +53,6 @@ def git_hook(
 
     :return number of errors if in strict mode, 0 otherwise.
     """
-
     # Get list of files modified and staged
     diff_cmd = ["git", "diff-index", "--cached", "--name-only", "--diff-filter=ACMRTUXB", "HEAD"]
     if lazy:

--- a/isort/io.py
+++ b/isort/io.py
@@ -66,7 +66,7 @@ class File:
 
 
 class _EmptyIO(StringIO):
-    def write(self, *args, **kwargs):
+    def write(self, *args, **kwargs):  # skipcq: PTC-W0049
         pass
 
 

--- a/isort/main.py
+++ b/isort/main.py
@@ -1089,6 +1089,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
                 show_diff=show_diff,
                 file_path=file_path,
                 extension=ext_format,
+                raise_on_skip=False,
             )
     elif "/" in file_names and not allow_root:
         printer = create_terminal_printer(color=config.color_output)

--- a/isort/wrap.py
+++ b/isort/wrap.py
@@ -130,9 +130,8 @@ def line(content: str, line_separator: str, config: Config = DEFAULT_CONFIG) -> 
                         lines[-1] = content + ")" + config.comment_prefix + comment[:-1]
                     return line_separator.join(lines)
                 return f"{content}{splitter}\\{line_separator}{cont_line}"
-    elif len(content) > config.line_length and wrap_mode == Modes.NOQA:  # type: ignore
-        if "# NOQA" not in content:
-            return f"{content}{config.comment_prefix} NOQA"
+    elif len(content) > config.line_length and wrap_mode == Modes.NOQA and "# NOQA" not in content:  # type: ignore
+        return f"{content}{config.comment_prefix} NOQA"
 
     return content
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -918,6 +918,31 @@ __revision__ = 'יייי'
     out, error = capsys.readouterr()
 
 
+def test_stream_skip_file(tmpdir, capsys):
+    input_with_skip = """
+# isort: skip_file
+import b
+import a
+"""
+    stream_with_skip = as_stream(input_with_skip)
+    main.main(["-"], stdin=stream_with_skip)
+    out, error = capsys.readouterr()
+    assert out == input_with_skip
+
+    input_without_skip = input_with_skip.replace("isort: skip_file", "generic comment")
+    stream_without_skip = as_stream(input_without_skip)
+    main.main(["-"], stdin=stream_without_skip)
+    out, error = capsys.readouterr()
+    assert (
+        out
+        == """
+# generic comment
+import a
+import b
+"""
+    )
+
+
 def test_only_modified_flag(tmpdir, capsys):
     # ensures there is no verbose output for correct files with only-modified flag
 


### PR DESCRIPTION
Addresses #1705: Makes the behavior of isort more intuitive when a skip file comment is encountered within a stream. Before it would stream out the exception, now it will simply stream out the remainder of the file without modification. This does mean any modifications that happened before the comment was encountered will still take place.