### PR TITLE
Update options.md regarding --atomic and Cython

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -468,7 +468,7 @@ Order imports by type, which is determined by case, in addition to alphabeticall
 
 ## Atomic
 
-Ensures the output doesn't save if the resulting file contains syntax errors.
+Ensures the output doesn't save if the resulting file contains syntax errors. This option is not compatible with Cython code.
 
 **Type:** Bool  
 **Default:** `False`  


### PR DESCRIPTION
Add note that --atomic is not compatible with Cython, as noted in #1722 

I've written "not compatible with Cython", but please shout up if "only compatible with pure Python" would be better wording (is anything except Python and Cython supported?).