### PR TITLE
Initialize `colorama` with `strip=False` to force color for non-tty output.

### DIFF
--- a/isort/format.py
+++ b/isort/format.py
@@ -11,7 +11,7 @@ except ImportError:
     colorama_unavailable = True
 else:
     colorama_unavailable = False
-    colorama.init()
+    colorama.init(strip=False)
 
 
 ADDED_LINE_PATTERN = re.compile(r"\+[^+]")


### PR DESCRIPTION
Fixes #1602.