### PR TITLE
Use a pipe to pass filenames to git check-ignore

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -2,7 +2,6 @@
 
 Defines how the default settings for isort should be loaded
 """
-import codecs
 import configparser
 import fnmatch
 import glob
@@ -544,16 +543,12 @@ class Config(_Config):
             git_folder = Path(topfolder_result.decode("utf-8").split("\n")[0])
 
             files = glob.glob(str(git_folder) + "/**/*", recursive=True)
-            files_result = (
-                codecs.escape_decode(  # type: ignore
-                    subprocess.check_output(  # nosec # skipcq: PYL-W1510
-                        ["git", "-C", str(git_folder), "check-ignore", *files]
-                    )
-                )[0]
-                .decode("utf-8")
-                .split("\n")
-            )
-            files_result = files_result[:-1] if files_result else files_result
+            files_result = subprocess.check_output(  # nosec # skipcq: PYL-W1510
+                ["git", "-C", str(git_folder), "check-ignore", "--stdin"],
+                encoding="utf-8",
+                env={"LANG": "C.UTF-8"},
+                input="\n".join(files),
+            ).splitlines()
 
             self.git_ignore[git_folder] = {Path(f.strip('"')) for f in files_result}
 


### PR DESCRIPTION
The number of files in a project could be larger than the limit on command-line arguments. Using a pipe avoids running into this issue.

Fixes #1758
