### PR TITLE
Add support for glob expansion in src_paths

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -794,7 +794,8 @@ Tells isort to honor noqa comments to enforce skipping those comments.
 
 ## Src Paths
 
-Add an explicitly defined source path (modules within src paths have their imports automatically categorized as first_party).
+Add an explicitly defined source path (modules within src paths have their imports automatically categorized as first_party). Glob expansion (`*` and `**`) is supported for this option.
+
 
 **Type:** Tuple  
 **Default:** `()`  

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -450,7 +450,7 @@ class Config(_Config):
         if "src_paths" not in combined_config:
             combined_config["src_paths"] = (path_root / "src", path_root)
         else:
-            src_paths: set[Path] = set()
+            src_paths: Set[Path] = set()
             for src_path in combined_config.get("src_paths", ()):
                 full_paths = (
                     path_root.glob(src_path) if "*" in str(src_path) else [path_root / src_path]

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -450,11 +450,13 @@ class Config(_Config):
         if "src_paths" not in combined_config:
             combined_config["src_paths"] = (path_root / "src", path_root)
         else:
-            src_paths: List[Path] = []
+            src_paths: set[Path] = set()
             for src_path in combined_config.get("src_paths", ()):
-                full_path = path_root / src_path
-                if full_path not in src_paths:
-                    src_paths.append(full_path)
+                full_paths = (
+                    path_root.glob(src_path) if "*" in str(src_path) else [path_root / src_path]
+                )
+                for path in full_paths:
+                    src_paths.add(path)
 
             combined_config["src_paths"] = tuple(src_paths)
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -90,7 +90,18 @@ class TestConfig:
     def test_src_paths_are_combined_and_deduplicated(self):
         src_paths = ["src", "tests"]
         src_full_paths = (Path(os.getcwd()) / f for f in src_paths)
-        assert Config(src_paths=src_paths * 2).src_paths == tuple(src_full_paths)
+        assert sorted(Config(src_paths=src_paths * 2).src_paths) == sorted(src_full_paths)
+
+    def test_src_paths_supports_glob_expansion(self, tmp_path):
+        libs = tmp_path / "libs"
+        libs.mkdir()
+        requests = libs / "requests"
+        requests.mkdir()
+        beautifulpasta = libs / "beautifulpasta"
+        beautifulpasta.mkdir()
+        assert sorted(Config(directory=tmp_path, src_paths=["libs/*"]).src_paths) == sorted(
+            (beautifulpasta, requests)
+        )
 
     def test_deprecated_multi_line_output(self):
         assert Config(multi_line_output=6).multi_line_output == WrapModes.VERTICAL_GRID_GROUPED  # type: ignore # noqa


### PR DESCRIPTION
As discussed in #1704, this adds support for glob expansion in paths provided with the `src_paths` config.