### PR TITLE
Some git ignore fixes

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -546,7 +546,7 @@ class Config(_Config):
         except subprocess.CalledProcessError:
             return None
 
-        git_folder = Path(topfolder_result.rstrip())
+        git_folder = Path(topfolder_result.rstrip()).resolve()
 
         files = [str(p) for p in Path(git_folder).rglob("*")]
         git_options = ["-C", str(git_folder), "-c", "core.quotePath="]
@@ -601,14 +601,15 @@ class Config(_Config):
 
             git_folder = None
 
+            file_paths = [file_path, file_path.resolve()]
             for folder in self.git_ignore:
-                if folder in file_path.parents:
+                if any(folder in path.parents for path in file_paths):
                     git_folder = folder
                     break
             else:
                 git_folder = self._check_folder_gitignore(str(file_path.parent))
 
-            if git_folder and file_path in self.git_ignore[git_folder]:
+            if git_folder and any(path in self.git_ignore[git_folder] for path in file_paths):
                 return True
 
         return False

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -4,7 +4,6 @@ Defines how the default settings for isort should be loaded
 """
 import configparser
 import fnmatch
-import glob
 import os
 import posixpath
 import re
@@ -549,7 +548,7 @@ class Config(_Config):
 
         git_folder = Path(topfolder_result.rstrip())
 
-        files = glob.glob(f"{git_folder}/**/*", recursive=True)
+        files = [str(p) for p in Path(git_folder).rglob("*")]
         git_options = ["-C", str(git_folder), "-c", "core.quotePath="]
         try:
             ignored = subprocess.check_output(  # nosec # skipcq: PYL-W1510


### PR DESCRIPTION
This PR fixes 3 problems with the current `.gitignore` implementation:
1) Currently, if you have any symbolic links in your project, the `git check-ignore` call in `_check_folder_gitignore` just dies and spams the console with `fatal: pathspec ... is beyond a symbolic link`.

    The first commit fixes this issue by replacing `glob.glob(recursive=True)` with `Path.rglob`, since `Path.rglob` doesn't recurse into symlinked directories.

---

Currently, the `file_path` argument of `Config.is_skipped` can be either an absolute or a relative path. I think, that directory paths are always passed as relative, while file paths are always passed as absolute, but don't quote me on that.

If it is a relative path, then the `skip_gitignore` code doesn't work correctly. This is fixed by the second commit, which checks both the original `file_path` and the resolved (absolute, no symlinks) `file_path`:

2) The `if folder in file_path.parents` line was supposed to check if the list of the ignored files was already generated, but it always fails for relative paths, which means that the costly `_check_folder_gitignore` function is called for each directory in the project.

3) The `if git_folder and file_path in self.git_ignore[git_folder]` line was supposed to check if the `file_path` should be ignored, which also doesn't work since `git rev-parse --show-toplevel` returns an absolute path and so all the paths in `self.git_ignore[git_folder]` are also absolute.

---

P.S.
- While working on this PR I found a flaky test, that I was able to reproduce on the current master by adding `@hypothesis.reproduce_failure('6.14.0', b'AAEGJwEZAQEiAQAA')` to `test_isort_doesnt_lose_imports_or_comments` in `tests/integration/test_setting_combinations.py` and running

    ```sh
    poetry run pytest tests/integration/test_setting_combinations.py::test_isort_doesnt_lose_imports_or_comments
    ```
- The `Test / build (3.7, macos-latest)` job also seems to be failing on the current master.