### PR TITLE
Update minimum pre-commit version to 2.9.2

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,4 @@
     language_version: python3
     types_or: [cython, pyi, python]
     args: ['--filter-files']
-    minimum_pre_commit_version: '2.9.0'
+    minimum_pre_commit_version: '2.9.2'


### PR DESCRIPTION
The PR which led to pre-commit 2.9.0 was [made by a data scientist](https://github.com/pre-commit/pre-commit/pull/1677) and so it [contains a bug](https://github.com/pre-commit/pre-commit/issues/1718), it'd be better to have 2.9.2 as the minimum version - at least, that's what Anthony Sottile suggested be done in `black` https://github.com/psf/black/pull/1875#discussion_r550571589