### PR TITLE
More extensive exception handling

### DIFF
--- a/isort/parse.py
+++ b/isort/parse.py
@@ -447,6 +447,10 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
                         f"could not place module {import_from} of line {line} --"
                         " Do you need to define a default section?"
                     )
+
+                if placed_module and placed_module not in imports:
+                    raise MissingSection(import_module=import_from, section=placed_module)
+
                 root = imports[placed_module][type_of_import]  # type: ignore
                 for import_name in just_imports:
                     associated_comment = nested_comments.get(import_name)

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -19,7 +19,7 @@ from isort import api, sections, files
 from isort.settings import Config
 
 from isort.utils import exists_case_sensitive
-from isort.exceptions import FileSkipped, ExistingSyntaxErrors
+from isort.exceptions import FileSkipped, ExistingSyntaxErrors, MissingSection
 from .utils import as_stream, UnreadableStream
 
 if TYPE_CHECKING:
@@ -2035,6 +2035,41 @@ def test_custom_sections() -> None:
         "import p24.imports._VERSION as VERSION\n"
         "import p24.shared.media_wiki_syntax as syntax\n"
     )
+
+
+def test_custom_sections_exception_handling() -> None:
+    """Ensure that appropriate exception is raised for missing sections"""
+    test_input = "import requests\n"
+
+    with pytest.raises(MissingSection):
+        isort.code(
+            code=test_input,
+            default_section="THIRDPARTY",
+            sections=[
+                "FUTURE",
+                "STDLIB",
+                "DJANGO",
+                "PANDAS",
+                "FIRSTPARTY",
+                "LOCALFOLDER",
+            ],
+        )
+
+    test_input = "from requests import get, post\n"
+
+    with pytest.raises(MissingSection):
+        isort.code(
+            code=test_input,
+            default_section="THIRDPARTY",
+            sections=[
+                "FUTURE",
+                "STDLIB",
+                "DJANGO",
+                "PANDAS",
+                "FIRSTPARTY",
+                "LOCALFOLDER",
+            ],
+        )
 
 
 def test_glob_known() -> None:


### PR DESCRIPTION
Based on issue #1807 where the error message is directly printed on the console, rather than raising the `MissingSections` exception with the more descriptive error message.