### PR TITLE
Run tests against Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, ubuntu-18.04, macos-latest, windows-latest]
 
     steps:
@@ -52,11 +52,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade poetry
-
-      # New poetry installer doesn't work well with Python 3.10 (see https://github.com/python-poetry/poetry/issues/4210).
-      - name: Use legacy poetry installer
-        if: startsWith(matrix.python-version, '3.10')
-        run: poetry config experimental.new-installer false
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
Python 3.10 having been [officially released](https://pythoninsider.blogspot.com/2021/10/python-3100-is-available.html) and being available for [setup-python](https://github.com/actions/python-versions/releases/tag/3.10.0-117470), we can replace the usage of `3.10.0-rc.2` to run tests on the CI for Python 3.10.

Using the legacy installer for Poetry on Python 3.10 is also not needed anymore, despite the issue [still being open](https://github.com/python-poetry/poetry/issues/4210), as a fix was made on [Poetry 1.1.11](https://github.com/python-poetry/poetry/releases/tag/1.1.11).