### PR TITLE
only skip real comments

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -1,6 +1,7 @@
 import textwrap
 from io import StringIO
 from itertools import chain
+from re import match
 from typing import List, TextIO, Union
 
 import isort.literal
@@ -9,7 +10,7 @@ from isort.settings import DEFAULT_CONFIG, Config
 from . import output, parse
 from .exceptions import FileSkipComment
 from .format import format_natural, remove_whitespace
-from .settings import FILE_SKIP_COMMENTS
+from .settings import FILE_SKIP_RE
 
 CIMPORT_IDENTIFIERS = ("cimport ", "cimport*", "from.cimport")
 IMPORT_START_IDENTIFIERS = ("from ", "from.import", "import ", "import*") + CIMPORT_IDENTIFIERS
@@ -150,12 +151,11 @@ def process(
             if stripped_line and not line_separator:
                 line_separator = line[len(line.rstrip()) :].replace(" ", "").replace("\t", "")
 
-            for file_skip_comment in FILE_SKIP_COMMENTS:
-                if line.startswith(file_skip_comment):
-                    if raise_on_skip:
-                        raise FileSkipComment("Passed in content")
-                    isort_off = True
-                    skip_file = True
+            if FILE_SKIP_RE.match(line):
+                if raise_on_skip:
+                    raise FileSkipComment("Passed in content")
+                isort_off = True
+                skip_file = True
 
             if not in_quote:
                 if stripped_line == "# isort: off":

--- a/isort/core.py
+++ b/isort/core.py
@@ -151,7 +151,7 @@ def process(
                 line_separator = line[len(line.rstrip()) :].replace(" ", "").replace("\t", "")
 
             for file_skip_comment in FILE_SKIP_COMMENTS:
-                if file_skip_comment in line:
+                if line.startswith(file_skip_comment):
                     if raise_on_skip:
                         raise FileSkipComment("Passed in content")
                     isort_off = True

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -55,8 +55,8 @@ CYTHON_EXTENSIONS = frozenset({"pyx", "pxd"})
 SUPPORTED_EXTENSIONS = frozenset({"py", "pyi", *CYTHON_EXTENSIONS})
 BLOCKED_EXTENSIONS = frozenset({"pex"})
 FILE_SKIP_COMMENTS: Tuple[str, ...] = (
-    "isort:" + "skip_file",
-    "isort: " + "skip_file",
+    "# isort:" + "skip_file",
+    "# isort: " + "skip_file",
 )  # Concatenated to avoid this file being skipped
 MAX_CONFIG_SEARCH_DEPTH: int = 25  # The number of parent directories to for a config file within
 STOP_CONFIG_SEARCH_ON_DIRS: Tuple[str, ...] = (".git", ".hg")

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -57,6 +57,8 @@ BLOCKED_EXTENSIONS = frozenset({"pex"})
 FILE_SKIP_COMMENTS: Tuple[str, ...] = (
     "# isort:" + "skip_file",
     "# isort: " + "skip_file",
+    "#isort:" + "skip_file",
+    "#isort: " + "skip_file",
 )  # Concatenated to avoid this file being skipped
 MAX_CONFIG_SEARCH_DEPTH: int = 25  # The number of parent directories to for a config file within
 STOP_CONFIG_SEARCH_ON_DIRS: Tuple[str, ...] = (".git", ".hg")

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -54,12 +54,7 @@ _SHEBANG_RE = re.compile(br"^#!.*\bpython[23w]?\b")
 CYTHON_EXTENSIONS = frozenset({"pyx", "pxd"})
 SUPPORTED_EXTENSIONS = frozenset({"py", "pyi", *CYTHON_EXTENSIONS})
 BLOCKED_EXTENSIONS = frozenset({"pex"})
-FILE_SKIP_COMMENTS: Tuple[str, ...] = (
-    "# isort:" + "skip_file",
-    "# isort: " + "skip_file",
-    "#isort:" + "skip_file",
-    "#isort: " + "skip_file",
-)  # Concatenated to avoid this file being skipped
+FILE_SKIP_RE = re.compile(r"^#?\s?isort:\s?skip_file")
 MAX_CONFIG_SEARCH_DEPTH: int = 25  # The number of parent directories to for a config file within
 STOP_CONFIG_SEARCH_ON_DIRS: Tuple[str, ...] = (".git", ".hg")
 VALID_PY_TARGETS: Tuple[str, ...] = tuple(

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -845,6 +845,13 @@ def test_skip_comment_without_space_after_hash() -> None:
         isort.code(test_input, known_third_party=["django"])
 
 
+def test_skip_comment_with_multiline_comment() -> None:
+    """Ensure skipping a whole file works."""
+    test_input = '"""some comment\n\nisort: skip_file\nimport django\nimport myproject\n"""'
+    with pytest.raises(FileSkipped):
+        isort.code(test_input, known_third_party=["django"])
+
+
 def test_skip_comment_is_no_comment() -> None:
     """Ensure skipping a whole file works."""
     test_input = 'content = "# isort:skip_file"'

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -837,6 +837,11 @@ def test_skip_within_file() -> None:
     with pytest.raises(FileSkipped):
         isort.code(test_input, known_third_party=["django"])
 
+def test_skip_comment_is_no_comment() -> None:
+    """Ensure skipping a whole file works."""
+    test_input = "content = \"# isort:skip_file\""
+    test_output = isort.code(test_input)
+    assert test_output == test_input
 
 def test_force_to_top() -> None:
     """Ensure forcing a single import to the top of its category works as expected."""

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -837,6 +837,12 @@ def test_skip_within_file() -> None:
     with pytest.raises(FileSkipped):
         isort.code(test_input, known_third_party=["django"])
 
+def test_skip_comment_without_space_after_hash() -> None:
+    """Ensure skipping a whole file works."""
+    test_input = "#isort: skip_file\nimport django\nimport myproject\n"
+    with pytest.raises(FileSkipped):
+        isort.code(test_input, known_third_party=["django"])
+
 def test_skip_comment_is_no_comment() -> None:
     """Ensure skipping a whole file works."""
     test_input = "content = \"# isort:skip_file\""
@@ -848,7 +854,6 @@ def test_force_to_top() -> None:
     test_input = "import lib6\nimport lib2\nimport lib5\nimport lib1\n"
     test_output = isort.code(test_input, force_to_top=["lib5"])
     assert test_output == "import lib5\nimport lib1\nimport lib2\nimport lib6\n"
-
 
 def test_add_imports() -> None:
     """Ensures adding imports works as expected."""

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -837,23 +837,27 @@ def test_skip_within_file() -> None:
     with pytest.raises(FileSkipped):
         isort.code(test_input, known_third_party=["django"])
 
+
 def test_skip_comment_without_space_after_hash() -> None:
     """Ensure skipping a whole file works."""
     test_input = "#isort: skip_file\nimport django\nimport myproject\n"
     with pytest.raises(FileSkipped):
         isort.code(test_input, known_third_party=["django"])
 
+
 def test_skip_comment_is_no_comment() -> None:
     """Ensure skipping a whole file works."""
-    test_input = "content = \"# isort:skip_file\""
+    test_input = 'content = "# isort:skip_file"'
     test_output = isort.code(test_input)
     assert test_output == test_input
+
 
 def test_force_to_top() -> None:
     """Ensure forcing a single import to the top of its category works as expected."""
     test_input = "import lib6\nimport lib2\nimport lib5\nimport lib1\n"
     test_output = isort.code(test_input, force_to_top=["lib5"])
     assert test_output == "import lib5\nimport lib1\nimport lib2\nimport lib6\n"
+
 
 def test_add_imports() -> None:
     """Ensures adding imports works as expected."""


### PR DESCRIPTION
I had the issue that I wrote a test for darker (https://github.com/akaihola/darker/pull/230) where I get an error because isort is handling every # isort: skip_file even if this is not a real comment.