### PR TITLE
Add tox config example

### DIFF
--- a/docs/configuration/config_files.md
+++ b/docs/configuration/config_files.md
@@ -61,6 +61,8 @@ Because isort verification is commonly ran as a testing step, some prefer to pla
 
 ```ini
 [isort]
+profile = black
+multi_line_output = 3
 ```
 
 ## .editorconfig


### PR DESCRIPTION
When I set the following config in `tox.ini`

```
[isort]
profile = "black"
multi_line_output = 3
```

I am getting the following error when running tox on py39:

```
  py39 run-test: commands[1] | poetry run isort obplatform -c
  Traceback (most recent call last):
    File "/home/runner/work/obplatform/obplatform/.tox/py39/bin/isort", line 8, in <module>
      sys.exit(main())
    File "/home/runner/work/obplatform/obplatform/.tox/py39/lib/python3.9/site-packages/isort/main.py", line 1108, in main
      config = Config(**config_dict)
    File "/home/runner/work/obplatform/obplatform/.tox/py39/lib/python3.9/site-packages/isort/settings.py", line 365, in __init__
      raise ProfileDoesNotExist(profile_name)
  isort.exceptions.ProfileDoesNotExist: Specified profile of "black" does not exist. Available profiles: black,django,pycharm,google,open_stack,plone,attrs,hug,wemake,appnexus.
```

I fixed it by removing the quotes around "black":

```
[isort]
profile = black
multi_line_output = 3
```

I think this example could be useful in the documentation.