### PR TITLE
Fix NOQA multiline mode. Use "NOQA: E501" instead of excessive "NOQA"…

### DIFF
--- a/isort/wrap.py
+++ b/isort/wrap.py
@@ -3,6 +3,7 @@ import re
 from typing import List, Optional, Sequence
 
 from .settings import DEFAULT_CONFIG, Config
+from .wrap_modes import SILENT_LENGTH_COMMENT
 from .wrap_modes import WrapModes as Modes
 from .wrap_modes import formatter_from_string
 
@@ -131,7 +132,7 @@ def line(content: str, line_separator: str, config: Config = DEFAULT_CONFIG) -> 
                     return line_separator.join(lines)
                 return f"{content}{splitter}\\{line_separator}{cont_line}"
     elif len(content) > config.line_length and wrap_mode == Modes.NOQA and "# NOQA" not in content:  # type: ignore
-        return f"{content}{config.comment_prefix} NOQA"
+        return f"{content}{config.comment_prefix} {SILENT_LENGTH_COMMENT}"
 
     return content
 

--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List
 import isort.comments
 
 _wrap_modes: Dict[str, Callable[..., str]] = {}
+SILENT_LENGTH_COMMENT = "NOQA: E501"
 
 
 def from_string(value: str) -> "WrapModes":
@@ -252,13 +253,13 @@ def noqa(**interface: Any) -> str:
             <= interface["line_length"]
         ):
             return f"{retval}{interface['comment_prefix']} {comment_str}"
-        if "NOQA" in interface["comments"]:
+        if "# NOQA" in f"{interface['comment_prefix']} {comment_str}":
             return f"{retval}{interface['comment_prefix']} {comment_str}"
-        return f"{retval}{interface['comment_prefix']} NOQA {comment_str}"
+        return f"{retval}{interface['comment_prefix']} {SILENT_LENGTH_COMMENT} {comment_str}"
 
     if len(retval) <= interface["line_length"]:
         return retval
-    return f"{retval}{interface['comment_prefix']} NOQA"
+    return f"{retval}{interface['comment_prefix']} {SILENT_LENGTH_COMMENT}"
 
 
 @_wrap_mode

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -487,7 +487,7 @@ def test_output_modes() -> None:
         "from third_party import lib1, lib2, lib3, lib4, lib5, lib6, lib7,"
         " lib8, lib9, lib10, lib11,"
         " lib12, lib13, lib14, lib15, lib16, lib17, lib18, lib20, lib21, lib22  "
-        "# NOQA comment\n"
+        "# NOQA: E501 comment\n"
     )
 
     test_case = isort.code(
@@ -1243,7 +1243,7 @@ def test_force_single_line_long_imports() -> None:
     )
     assert test_output == (
         "from veryveryveryveryveryvery import big\n"
-        "from veryveryveryveryveryvery import small  # NOQA\n"
+        "from veryveryveryveryveryvery import small  # NOQA: E501\n"
     )
 
 

--- a/tests/unit/test_wrap_modes.py
+++ b/tests/unit/test_wrap_modes.py
@@ -29,7 +29,7 @@ def test_auto_saved():
                 "white_space": "\U000a7322\U000c20e3-\U0010eae4\x07\x14\U0007d486",
             }
         )
-        == "\U00092452-\U000bf82c\x0c\U0004608f\x10% NOQA"
+        == "\U00092452-\U000bf82c\x0c\U0004608f\x10% NOQA: E501"
     )
     assert (
         wrap_modes.noqa(


### PR DESCRIPTION
With config:
```
multi_line_output = 7
```

if we have something like this as input (with a comment other than "# NOQA"):
```
from very.very.very.very.very.very.very.very.very.very.very.very.very.long import bar, foo  # some comment  # NOQA
```

then we get the following error over and over again:
> isort some_file.py
```
from very.very.very.very.very.very.very.very.very.very.very.very.very.long import bar, foo  # NOQA some comment  # NOQA
```

> isort some_file.py
```
from very.very.very.very.very.very.very.very.very.very.very.very.very.long import bar, foo  # NOQA NOQA some comment  # NOQA
```
etc.

This problem is relevant if, for example, we want to clarify that we are only interested in ignoring the error by the length of the line.
```
from very.very.very.very.very.very.very.very.very.very.very.very.very.long import bar, foo  # NOQA: E501
```
```
from very.very.very.very.very.very.very.very.very.very.very.very.very.long import bar, foo  # NOQA NOQA: E501
```
```
from very.very.very.very.very.very.very.very.very.very.very.very.very.long import bar, foo  # NOQA NOQA NOQA: E501
```
etc.

Also, I changed to use the default "NOQA: E501" instead of the excessive "NOQA" (with the ability for the user to change this to other variations in the comment code)