### PR TITLE
Remove redundant `multi_line_output = 3` from "Compatibility with black"

### DIFF
--- a/docs/configuration/black_compatibility.md
+++ b/docs/configuration/black_compatibility.md
@@ -20,7 +20,6 @@ For instance, your _pyproject.toml_ file would look something like
 ```ini
 [tool.isort]
 profile = "black"
-multi_line_output = 3
 ```
 
 Read More about supported [config files](https://pycqa.github.io/isort/docs/configuration/config_files.html).
@@ -64,4 +63,3 @@ You can also set the profile directly when integrating isort within pre-commit.
       - id: isort
         args: ["--profile", "black", "--filter-files"]
 ```
-


### PR DESCRIPTION
According to the profiles documentation:
https://pycqa.github.io/isort/docs/configuration/profiles.html

The black profiles contains: "multi_line_output = 3". Avoid confusion on
the "Compatibility with black" page by not adding a redundant option.
The reader may believe the extra "multi_line_output" is required.

This came up in a real world scenario:
https://github.com/pypa/pep517/pull/137#discussion_r756648644