### PR TITLE
Fix `FileNotFoundError` raised by `_check_folder_gitignore`

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -555,7 +555,10 @@ class Config(_Config):
         env = {**os.environ, "LANG": "C.UTF-8"}
         try:
             topfolder_result = subprocess.check_output(  # nosec # skipcq: PYL-W1510
-                ["git", "-C", folder, "rev-parse", "--show-toplevel"], encoding="utf-8", env=env
+                ["git", "-C", folder, "rev-parse", "--show-toplevel"],
+                encoding="utf-8",
+                env=env,
+                shell=True,
             )
         except subprocess.CalledProcessError:
             return None


### PR DESCRIPTION
Current version raised `FileNotFoundError ` when `git` is not installed.

E.g.
CI using docker image: python:slim which has no git installed by default.
<img width="1038" alt="Screen Shot 2021-12-01 at 10 57 57" src="https://user-images.githubusercontent.com/4580133/144164143-6732dce1-8b04-4830-ab2f-aa7f45bf891d.png">

