### PR TITLE
Add a command-line flag to sort __all__ re-exports (#1862)

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -322,6 +322,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="format_success",
         help="Override the format used to print success.",
     )
+    general_group.add_argument(
+        "--sort-reexports",
+        dest="sort_reexports",
+        action="store_true",
+        help="Automatically sort all re-exports (module level __all__ collections)",
+    )
 
     target_group.add_argument(
         "files", nargs="*", help="One or more Python source files that need their imports sorted."

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -242,6 +242,7 @@ class _Config:
     format_error: str = "{error}: {message}"
     format_success: str = "{success}: {message}"
     sort_order: str = "natural"
+    sort_reexports: bool = False
 
     def __post_init__(self) -> None:
         py_version = self.py_version


### PR DESCRIPTION
This PR adds a `--sort-reexports` CLI flag and the respective cfg and toml options to isort, which allows for similar behaviour to `# isort: [list|tuple|dict]` without the need to have comments scattered around. See #1862 for more information.

This PR makes no attempt to document this feature at present, but I'm happy to do this if you'd like me to.

Closes #1862.