### PR TITLE
Fix build-backend values in the example plugins

### DIFF
--- a/example_isort_formatting_plugin/pyproject.toml
+++ b/example_isort_formatting_plugin/pyproject.toml
@@ -17,4 +17,4 @@ black = ">20.08b1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"

--- a/example_isort_sorting_plugin/pyproject.toml
+++ b/example_isort_sorting_plugin/pyproject.toml
@@ -16,4 +16,4 @@ natsort = ">=7.1.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"

--- a/example_shared_isort_profile/pyproject.toml
+++ b/example_shared_isort_profile/pyproject.toml
@@ -15,4 +15,4 @@ python = ">=3.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The example plugins are declaring a requirement on poetry-core but using
the "main" poetry build backend.  Correct them to use the poetry.core
backend.