### PR TITLE
Document shared profiles

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1132,7 +1132,10 @@ Inserts a blank line before a comment following an import.
 
 ## Profile
 
-Base profile type to use for configuration. Profiles include: black, django, pycharm, google, open_stack, plone, attrs, hug, wemake, appnexus. As well as any shared profiles.
+Base profile type to use for configuration. Profiles include: black, django,
+pycharm, google, open\_stack, plone, attrs, hug, wemake, appnexus. As well as
+any [shared
+profiles](https://pycqa.github.io/isort/docs/howto/shared_profiles.html).
 
 **Type:** String  
 **Default:** ` `  

--- a/docs/howto/shared_profiles.md
+++ b/docs/howto/shared_profiles.md
@@ -1,0 +1,18 @@
+# Shared Profiles
+
+As well as the [built in
+profiles](https://pycqa.github.io/isort/docs/configuration/profiles.html), you
+can define and share your own profiles.
+
+All that's required is to create a Python package that exposes an entry point to
+a dictionary exposing profile settings under `isort.profiles`. An example is
+available [within the `isort`
+repo](https://github.com/PyCQA/isort/tree/main/example_shared_isort_profile)
+
+### Example `.isort.cfg`
+
+```
+[options.entry_points]
+isort.profiles =
+    shared_profile=my_module:PROFILE
+```


### PR DESCRIPTION
These were added with 2d76984f1345763f31aff8c1fc940000700cd46e, with
tests and an example added with
57eb70a4c70311f6b1748062853ded38f7fec366. Add some documentation on how
these can be created, including a link to the example profile in this
repo.

Add a link to these docs from where shared profiles are mentioned for
the `profile` config