### PR TITLE
Update plone profile: copy of black, plus three settings.

### DIFF
--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -33,12 +33,14 @@ open_stack = {
     "force_sort_within_sections": True,
     "lexicographical": True,
 }
-plone = {
-    "force_alphabetical_sort": True,
-    "force_single_line": True,
-    "lines_after_imports": 2,
-    "line_length": 200,
-}
+plone = black.copy()
+plone.update(
+    {
+        "force_alphabetical_sort": True,
+        "force_single_line": True,
+        "lines_after_imports": 2,
+    }
+)
 attrs = {
     "atomic": True,
     "force_grid_wrap": 0,


### PR DESCRIPTION
Fixes https://github.com/PyCQA/isort/issues/1925

The Plone-related tests pass, three others fail. Should be unrelated, or maybe a bad setup locally:

```
FAILED tests/unit/test_literal.py::test_value_assignment_list - isort.exceptions.FormattingPluginDoesNotExist: Specified formatting plugin of example does not exist.
FAILED tests/unit/test_ticketed_features.py::test_isort_supports_formatting_plugins_issue_1353 - isort.exceptions.FormattingPluginDoesNotExist: Specified formatting plugin of example does not exist.
FAILED tests/unit/test_ticketed_features.py::test_isort_literals_issue_1358 - isort.exceptions.FormattingPluginDoesNotExist: Specified formatting plugin of example does not exist.
```

Also, `./scripts/test.sh` fails because some security updates need to be added, so `poetry update` needs to run, but that fails, see issue #1915.