### PR TITLE
docs: fix simple typo, detrmination -> determination

### DIFF
--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -12,7 +12,7 @@ from isort import Config, api, exceptions
 
 def test_semicolon_ignored_for_dynamic_lines_after_import_issue_1178():
     """Test to ensure even if a semicolon is in the decorator in the line following an import
-    the correct line spacing detrmination will be made.
+    the correct line spacing determination will be made.
     See: https://github.com/pycqa/isort/issues/1178.
     """
     assert isort.check_code(


### PR DESCRIPTION
There is a small typo in tests/unit/test_ticketed_features.py.

Should read `determination` rather than `detrmination`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md