### PR TITLE
Fix #1964: `lines_before_import` sometimes ignored

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -359,7 +359,7 @@ def process(
         if not_imports:
 
             if not was_in_quote and config.lines_before_imports > -1:
-                if line.strip() == "":
+                if line.strip() == "" and not end_of_file:
                     lines_before += line
                     continue
                 if not import_section:

--- a/isort/output.py
+++ b/isort/output.py
@@ -183,6 +183,10 @@ def sorted_imports(
         ] == [""]:
             formatted_output.pop(imports_tail)
 
+        if config.lines_before_imports != -1:
+            formatted_output[:0] = ["" for line in range(config.lines_before_imports)]
+            imports_tail += config.lines_before_imports
+
         if len(formatted_output) > imports_tail:
             next_construct = ""
             tail = formatted_output[imports_tail:]
@@ -216,9 +220,6 @@ def sorted_imports(
                 formatted_output[imports_tail:0] = ["", ""]
             else:
                 formatted_output[imports_tail:0] = [""]
-
-            if config.lines_before_imports != -1:
-                formatted_output[:0] = ["" for line in range(config.lines_before_imports)]
 
     if parsed.place_imports:
         new_out_lines = []

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -1714,12 +1714,13 @@ def test_order_by_type() -> None:
     )
 
 
-def test_custom_lines_before_import_section() -> None:
-    """Test the case where the number of lines to output after imports has been explicitly set."""
-    test_input = """from a import b
-
-foo = 'bar'
-"""
+@pytest.mark.parametrize("has_body", [True, False])
+# @pytest.mark.parametrize("has_body", [False])
+def test_custom_lines_before_import_section(has_body) -> None:
+    """Test the case where the number of lines to output before imports has been explicitly set."""
+    test_input = "from a import b\n"
+    if has_body:
+        test_input += "\nfoo = 'bar'\n"
 
     ln = "\n"
 


### PR DESCRIPTION
The config option `lines_before_import` was ignored if the file only contained
imports + optionally a leading comment.