### PR TITLE
Fix #1855: fix check if file altered

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -506,4 +506,4 @@ def _has_changed(before: str, after: str, line_separator: str, ignore_whitespace
             remove_whitespace(before, line_separator=line_separator).strip()
             != remove_whitespace(after, line_separator=line_separator).strip()
         )
-    return before.strip() != after.strip()
+    return before != after


### PR DESCRIPTION
When checking if a file got altered, leading and trailing white space is infact
relevant. Especially considering the existence of config options like
`lines_before_imports` and `lines_after_imports`.