### PR TITLE
Remove language_version for pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,6 @@
     entry: isort
     require_serial: true
     language: python
-    language_version: python3
     types_or: [cython, pyi, python]
     args: ['--filter-files']
     minimum_pre_commit_version: '2.9.2'


### PR DESCRIPTION
Removing language_version enables to use default_language_version.

See: https://github.com/PyCQA/isort/issues/1988

I think this is the modern way for hook definitions. For example popular pre-commit hook from `black` project does not specify `language_version` anymore, see: https://github.com/psf/black/pull/2430