### PR TITLE
Fix Pyodide CDN URL

### DIFF
--- a/docs/quick_start/0.-try.md
+++ b/docs/quick_start/0.-try.md
@@ -9,9 +9,9 @@ Use our live isort editor to see how isort can help improve the formatting of yo
 <head>
 <script type="text/javascript">
     // set the pyodide files URL (packages.json, pyodide.asm.data etc)
-    window.languagePluginUrl = 'https://pyodide-cdn2.iodide.io/v0.15.0/full/';
+    window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.15.0/full/';
 </script>
-<script src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
+<script src="https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js" integrity="sha256-W+0Mr+EvJb1qJx9UZ9wuvd/uWrXCzeaEu6OzEEHMCik=" crossorigin="anonymous"></script>
 <script src="https://pagecdn.io/lib/ace/1.4.5/ace.js" integrity="sha256-5Xkhn3k/1rbXB+Q/DX/2RuAtaB4dRRyQvMs83prFjpM=" crossorigin="anonymous"></script>
 <link rel="stylesheet" type="text/css" href="https://pycqa.github.io/isort/docs/quick_start/interactive.css">
 </head>


### PR DESCRIPTION
The previous deprecated CDN was recently taken down (pyodide/pyodide#3150).