### PR TITLE
Derive `settings_path` from `--filename`

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1087,7 +1087,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
         return
     if "settings_path" not in arguments:
         arguments["settings_path"] = (
-            os.path.abspath(file_names[0] if file_names else ".") or os.getcwd()
+            os.path.abspath(file_names[0] if file_names else ".")
         )
         if not os.path.isdir(arguments["settings_path"]):
             arguments["settings_path"] = os.path.dirname(arguments["settings_path"])

--- a/isort/main.py
+++ b/isort/main.py
@@ -1087,6 +1087,8 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
         return
     if "settings_path" not in arguments:
         arguments["settings_path"] = (
+            arguments.get("filename", None) or os.getcwd()
+            if file_names == ["-"] else
             os.path.abspath(file_names[0] if file_names else ".")
         )
         if not os.path.isdir(arguments["settings_path"]):


### PR DESCRIPTION


Fixes #1989

`--filename` is a shortcut setting used only in the stdin case to set
the `settings_path`.
Generally, `--settings-path=<file_path>` == `--filename=<filename>`
should hold.

This functionality was removed in 09734212 (Reuse config when items
passed in through stdin as used when items passed in explicitly).
