### PR TITLE
Do not cache configuration files

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -825,7 +825,7 @@ def find_all_configs(path: str) -> Trie:
     return trie_root
 
 
-def _get_config_data(file_path: str, sections: Tuple[str]) -> Dict[str, Any]:
+def _get_config_data(file_path: str, sections: Tuple[str, ...]) -> Dict[str, Any]:
     settings: Dict[str, Any] = {}
 
     if file_path.endswith(".toml"):

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -11,7 +11,6 @@ import stat
 import subprocess  # nosec: Needed for gitignore support.
 import sys
 from dataclasses import dataclass, field
-from functools import lru_cache
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -766,7 +765,6 @@ def _abspaths(cwd: str, values: Iterable[str]) -> Set[str]:
     return paths
 
 
-@lru_cache()
 def _find_config(path: str) -> Tuple[str, Dict[str, Any]]:
     current_directory = path
     tries = 0
@@ -799,7 +797,6 @@ def _find_config(path: str) -> Tuple[str, Dict[str, Any]]:
     return (path, {})
 
 
-@lru_cache()
 def find_all_configs(path: str) -> Trie:
     """
     Looks for config files in the path provided and in all of its sub-directories.
@@ -828,7 +825,6 @@ def find_all_configs(path: str) -> Trie:
     return trie_root
 
 
-@lru_cache()
 def _get_config_data(file_path: str, sections: Tuple[str]) -> Dict[str, Any]:
     settings: Dict[str, Any] = {}
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -126,8 +126,6 @@ def test_find_config(tmpdir):
     tmp_config = tmpdir.join(".isort.cfg")
 
     # can't find config if it has no relevant section
-    settings._find_config.cache_clear()
-    settings._get_config_data.cache_clear()
     tmp_config.write_text(
         """
 [section]
@@ -138,14 +136,10 @@ force_grid_wrap=true
     assert not settings._find_config(str(tmpdir))[1]
 
     # or if it is malformed
-    settings._find_config.cache_clear()
-    settings._get_config_data.cache_clear()
     tmp_config.write_text("""arstoyrsyan arienrsaeinrastyngpuywnlguyn354q^%$)(%_)@$""", "utf8")
     assert not settings._find_config(str(tmpdir))[1]
 
     # can when it has either a file format, or generic relevant section
-    settings._find_config.cache_clear()
-    settings._get_config_data.cache_clear()
     _write_simple_settings(tmp_config)
     assert settings._find_config(str(tmpdir))[1]
 
@@ -155,8 +149,6 @@ def test_find_config_deep(tmpdir):
     dirs = [f"dir{i}" for i in range(settings.MAX_CONFIG_SEARCH_DEPTH + 1)]
     tmp_dirs = tmpdir.ensure(*dirs, dirs=True)
     tmp_config = tmpdir.join("dir0", ".isort.cfg")
-    settings._find_config.cache_clear()
-    settings._get_config_data.cache_clear()
     _write_simple_settings(tmp_config)
     assert not settings._find_config(str(tmp_dirs))[1]
     # but can find config if it is MAX_CONFIG_SEARCH_DEPTH up

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -555,7 +555,6 @@ def test_isort_respects_quiet_from_sort_file_api_see_1461(capsys, tmpdir):
     assert not out
 
     # Present in an automatically loaded configuration file
-    isort.settings._find_config.cache_clear()
     settings_file.write(
         """
 [isort]
@@ -610,7 +609,6 @@ quiet = true
     with pytest.warns(UserWarning):
         assert not Config(settings_file=str(settings_file)).quiet
 
-    isort.settings._get_config_data.cache_clear()
     settings_file.write(
         """
 [isort]


### PR DESCRIPTION
Fixes #1994

isort can run in long processes when used in an editor.  In that scenario it is confusing for users when editing a configuration file does not change isorts outcome.

Remove the caches in `settings.py` completely to re-read the configuration on each run.

This is safe for the CLI case as we here either use the `Trie` implementation which collects all known configuration files beforehand, or we exactly construct one `Config` object based on the first filename, the working dir, or the explicit `settings_path|file` settings.

Not caching is therefore more efficient for the CLI case and more useful for the editor case.