### PR TITLE
Disregard skip options for streamed files

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1134,6 +1134,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
                 show_diff=show_diff,
                 file_path=file_path,
                 extension=ext_format,
+                disregard_skip=True,
             )
 
             wrong_sorted_files = incorrectly_sorted
@@ -1147,6 +1148,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
                     file_path=file_path,
                     extension=ext_format,
                     raise_on_skip=False,
+                    disregard_skip=True,
                 )
             except FileSkipped:
                 sys.stdout.write(input_stream.read())


### PR DESCRIPTION
`skip_gitignore` is kinda slow, but it's much faster than having to process all files in the repo. At least when I'm processing multiple files at once.

During daily development, I use the vscode "Sort Imports" feature, which internally streams the contents of the file to `isort`. In this case, it is unbearably slow:

```
$ time echo 123 | isort - --filename=/code/foobar.py
123

real    0m0.195s
user    0m0.089s
sys     0m0.025s

$ time echo 123 | isort - --filename=/code/foobar.py --gitignore
123

real    0m7.326s
user    0m3.382s
sys     0m1.737s
```

That's 37 times slower.

If we're streaming in data, it probably makes sense to just disregard all skip conditions.