### PR TITLE
tests must install `example_isort_formatting_plugin`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,8 @@ jobs:
 
       - name: Test
         shell: bash
-        run: |
-          poetry run pytest tests/unit/ -s --cov=isort/ --cov-report=term-missing ${@-}
-          poetry run coverage xml
+        run: ./scripts/test.sh
+
       - name: Report Coverage
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         uses: codecov/codecov-action@v1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-./scripts/lint.sh
+cd example_isort_formatting_plugin && poetry install
+cd ..
 poetry run pytest tests/unit/ -s --cov=isort/ --cov-report=term-missing ${@-} --ignore=tests/unit/test_deprecated_finders.py
 poetry run coverage html


### PR DESCRIPTION
Fix failing Actions. It would appear the [original PR](https://github.com/PyCQA/isort/commit/b40e584d0742a52fc061f4dd55a4e8469d19c34f) for this feature never installed the example plugin!!

Closes #2012