### PR TITLE
Only call `colorama.init` if `colorama` is available

### DIFF
--- a/isort/format.py
+++ b/isort/format.py
@@ -150,7 +150,8 @@ def create_terminal_printer(
         print(no_colorama_message, file=sys.stderr)
         sys.exit(1)
 
-    colorama.init(strip=False)
+    if not colorama_unavailable:
+        colorama.init(strip=False)
     return (
         ColoramaPrinter(error, success, output) if color else BasicPrinter(error, success, output)
     )


### PR DESCRIPTION
Resolves #2031 

Hello!

## Pull Request Overview
* Only call `colorama.init` if `colorama` could be imported.

## After this PR
After applying the reproduction steps from #2031, the command now terminates normally, as opposed to the `NameError` from before. 

Let me know if you need anything else from me!

- Tom Aarsen