### PR TITLE
Only run release workflows for upstream

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,7 @@ name: Release Drafter
 
 jobs:
   draft_release:
+    if: github.repository_owner == 'PyCQA'
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ name: Release
 
 jobs:
   release:
+    if: github.repository_owner == 'PyCQA'
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When pushing `main` on a fork, the release workflow triggers but, as expected, fails to deploy to PyPI because API tokens are missing from forks:

```
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
         Invalid or non-existent authentication information. See                
         https://pypi.org/help/#invalid-auth for more information.              
```

Before: https://github.com/hugovk/isort/actions/runs/3719681768/jobs/6308688909

Let's skip the release workflow for forks.

After: https://github.com/hugovk/isort/actions/runs/3719767321

Also, whilst the release drafter does work for forks, let's only run that for upstream too.