### PR TITLE
Stop installing documentation files to top-level site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ classifiers = [
 urls = { Changelog = "https://github.com/pycqa/isort/blob/main/CHANGELOG.md" }
 include = [
     { path = "tests", format = "sdist" },
-    { path = "ACKNOWLEDGEMENTS.md" },
-    { path = "CHANGELOG.md" },
-    { path = "LICENSE" },
+    { path = "ACKNOWLEDGEMENTS.md", format = "sdist" },
+    { path = "CHANGELOG.md", format = "sdist" },
+    { path = "LICENSE", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Add `format = sdist` to `include` table values to prevent the documentation files from being installed directly into site-packages, i.e.:

    /usr/lib/python3.11/site-packages/CHANGELOG.md
    /usr/lib/python3.11/site-packages/LICENSE

Originally reported by Anna Vyalkova on https://bugs.gentoo.org/887569.