### PR TITLE
Remove unnecessary parentheses, use f-string, rm "object"

### DIFF
--- a/isort/deprecated/finders.py
+++ b/isort/deprecated/finders.py
@@ -391,10 +391,8 @@ class FindersManager:
                 # if one finder fails to instantiate isort can continue using the rest
                 if self.verbose:
                     print(
-                        (
-                            f"{finder_cls.__name__} encountered an error ({exception}) during "
-                            "instantiation and cannot be used"
-                        )
+                        f"{finder_cls.__name__} encountered an error ({exception}) during "
+                        "instantiation and cannot be used"
                     )
         self.finders: Tuple[BaseFinder, ...] = tuple(finders)
 

--- a/isort/main.py
+++ b/isort/main.py
@@ -966,7 +966,7 @@ def _preconvert(item: Any) -> Union[str, List[Any]]:
         return str(item)
     if callable(item) and hasattr(item, "__name__"):
         return str(item.__name__)
-    raise TypeError("Unserializable object {} of type {}".format(item, type(item)))
+    raise TypeError(f"Unserializable object {item} of type {type(item)}")
 
 
 def identify_imports_main(

--- a/isort/output.py
+++ b/isort/output.py
@@ -562,7 +562,7 @@ def _with_straight_imports(
 ) -> List[str]:
     output: List[str] = []
 
-    as_imports = any((module in parsed.as_map["straight"] for module in straight_modules))
+    as_imports = any(module in parsed.as_map["straight"] for module in straight_modules)
 
     # combine_straight_imports only works for bare imports, 'as' imports not included
     if config.combine_straight_imports and not as_imports:

--- a/scripts/check_acknowledgments.py
+++ b/scripts/check_acknowledgments.py
@@ -46,13 +46,11 @@ async def main():
             )
             results = response.json()
             contributors.extend(
-                (
-                    contributor
-                    for contributor in results
-                    if contributor["type"] == GITHUB_USER_TYPE
-                    and contributor["login"] not in IGNORED_AUTHOR_LOGINS
-                    and f"@{contributor['login'].lower()}" not in ACKNOWLEDGEMENTS
-                )
+                contributor
+                for contributor in results
+                if contributor["type"] == GITHUB_USER_TYPE
+                and contributor["login"] not in IGNORED_AUTHOR_LOGINS
+                and f"@{contributor['login'].lower()}" not in ACKNOWLEDGEMENTS
             )
 
         unacknowledged_users = await asyncio.gather(

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -65,7 +65,7 @@ def test_git_hook(src_dir):
         "isort.hooks.get_lines", MagicMock(return_value=[os.path.join(src_dir, "main.py")])
     ) as run_mock:
 
-        class FakeProcessResponse(object):
+        class FakeProcessResponse:
             stdout = b"# isort: skip-file\nimport b\nimport a\n"
 
         with patch("subprocess.run", MagicMock(return_value=FakeProcessResponse())) as run_mock:

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -3017,7 +3017,7 @@ def test_import_by_paren_issue_460() -> None:
 import io
 import os
 """
-    assert isort.code((test_input)) == test_input
+    assert isort.code(test_input) == test_input
 
 
 def test_function_with_docstring() -> None:
@@ -3780,7 +3780,7 @@ def test_command_line(tmpdir, capfd, multiprocess: bool) -> None:
 
     tmpdir.join("file1.py").write("import re\nimport os\n\nimport contextlib\n\n\nimport isort")
     tmpdir.join("file2.py").write(
-        ("import collections\nimport time\n\nimport abc" "\n\n\nimport isort")
+        "import collections\nimport time\n\nimport abc" "\n\n\nimport isort"
     )
     arguments = [str(tmpdir), "--settings-path", os.getcwd()]
     if multiprocess:


### PR DESCRIPTION
These changes were discovered using:

    pyupgrade --py37-plus `find . -name "*.py"`