### PR TITLE
Fix poetry pip-shims extras dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -998,6 +998,7 @@ category = "dev"
 optional = false
 python-versions = "*"
 files = [
+    {file = "livereload-2.6.3-py2.py3-none-any.whl", hash = "sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4"},
     {file = "livereload-2.6.3.tar.gz", hash = "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"},
 ]
 
@@ -1290,7 +1291,7 @@ setuptools = "*"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1447,8 +1448,8 @@ pip = "*"
 name = "pip-shims"
 version = "0.7.3"
 description = "Compatibility shims for pip versions 8 thru current."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "pip_shims-0.7.3-py2.py3-none-any.whl", hash = "sha256:2ae9f21c0155ca5c37d2734eb5f9a7d98c4c42a122d1ba3eddbacc9d9ea9fbae"},
@@ -1760,7 +1761,7 @@ markdown = ">=3.2"
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.8"
 files = [
@@ -2037,6 +2038,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
@@ -2517,8 +2519,8 @@ files = [
 name = "wheel"
 version = "0.38.4"
 description = "A built-package format for Python"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "wheel-0.38.4-py3-none-any.whl", hash = "sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8"},
@@ -2573,11 +2575,11 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [extras]
 colors = ["colorama"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib", "pip-shims"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pipreqs", "pip-api"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0"
-content-hash = "f9753af4afcf7d147259494131df7b109827364ce0985cc64637b0b991057ed5"
+content-hash = "12bdab97e0f5e0c0180048f35c7b83290a6ebedc65dda5ab004cb08c37b28944"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,13 @@ include = [
 python = ">=3.8.0"
 pipreqs = {version = "*", optional = true}
 requirementslib = {version = "*", optional = true}
+pip-shims = {version = ">=0.5.2", optional = true}
 pip-api = {version = "*", optional = true}
 colorama = {version = ">=0.4.3", optional = true}
 setuptools = {version = "*", optional = true}
 
 [tool.poetry.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib", "pip-shims<=0.3.4"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib", "pip-shims"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama"]
 plugins = ["setuptools"]
@@ -77,7 +78,6 @@ pipreqs = ">=0.4.9"
 pip_api = ">=0.0.12"
 pylama = ">=7.7"
 pip = ">=21.1.1"
-pip-shims = ">=0.5.2"
 py = ">=1.11.0"
 safety = ">=2.2.0"
 smmap2 = ">=3.0.1"


### PR DESCRIPTION
With poetry-core>=1.5.0, the dependencies in extras must be present in the main dependency group.

Fix #2077