### PR TITLE
Fix a tip block styling in the Config Files section

### DIFF
--- a/docs/configuration/config_files.md
+++ b/docs/configuration/config_files.md
@@ -115,4 +115,4 @@ directory_root
 isort will sort `subdir1/file1` according to the configurations defined in `subdir1/.isort.cfg`, `subdir2/file2` with configurations from `subdir2/pyproject.toml` and `subdir3/file3.py` based on the `setup.cfg` settings.
 
 !!! tip
-You can always confirm exactly what config file was used for a file by running isort with the `--verbose` flag.
+    You can always confirm exactly what config file was used for a file by running isort with the `--verbose` flag.


### PR DESCRIPTION
Hi! Noticed, that the tip block at the end of the Config Files page looks broken. Here's a fix.

![Screenshot from 2023-02-15 18-45-58](https://user-images.githubusercontent.com/56698047/219078203-a52d988f-d590-4559-991c-1d36e9fd7730.png)
