### PR TITLE
Skip .pytype directory by default.

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -60,7 +60,7 @@ Force specific imports to the top of their appropriate section.
 Files that isort should skip over. If you want to skip multiple files you should specify twice: `--skip file1 --skip file2`. Values can be file names, directory names or file paths. To skip all files in a nested path, use [`--skip-glob`](#skip-glob). To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
 
 **Type:** List of Strings  
-**Default:** `('.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv')`  
+**Default:** `('.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.pytype' '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv')`  
 **Config default:** `['.bzr', '.direnv', '.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.svn', '.tox', '.venv', '__pypackages__', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv']`  
 **Python & Config File Name:** skip  
 **CLI Flags:**

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -89,6 +89,7 @@ DEFAULT_SKIP: FrozenSet[str] = frozenset(
         ".direnv",
         "node_modules",
         "__pypackages__",
+        ".pytype",
     }
 )
 


### PR DESCRIPTION
Pytype stores .pyi files in .pytype that isort shouldn’t check or touch.