### PR TITLE
Update version in pre-commit setup to avoid installation issue with poetry 

### DIFF
--- a/docs/configuration/pre-commit.md
+++ b/docs/configuration/pre-commit.md
@@ -9,7 +9,7 @@ To use isort's official pre-commit integration add the following config:
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort (python)
@@ -20,7 +20,7 @@ over different file types (ex: python vs cython vs pyi) you can do so with the f
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
Updated the pre-commit setup to version 5.11.5 for the poetry hotfix, while keeping Python 3.7 support.