### PR TITLE
Fix config overriding with --resolve-all-configs

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1111,14 +1111,14 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
     all_attempt_broken = False
     no_valid_encodings = False
 
-    config_trie: Optional[Trie] = None
-    if resolve_all_configs:
-        config_trie = find_all_configs(config_dict.pop("config_root", "."))
-
     if "src_paths" in config_dict:
         config_dict["src_paths"] = {
             Path(src_path).resolve() for src_path in config_dict.get("src_paths", ())
         }
+
+    config_trie: Optional[Trie] = None
+    if resolve_all_configs:
+        config_trie = find_all_configs(config_dict.pop("config_root", "."), config_dict)
 
     config = Config(**config_dict)
     if show_config:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -798,7 +798,7 @@ def _find_config(path: str) -> Tuple[str, Dict[str, Any]]:
     return (path, {})
 
 
-def find_all_configs(path: str) -> Trie:
+def find_all_configs(path: str, config_overrides: Dict[str, Any]) -> Trie:
     """
     Looks for config files in the path provided and in all of its sub-directories.
     Parses and stores any config file encountered in a trie and returns the root of
@@ -820,6 +820,7 @@ def find_all_configs(path: str) -> Trie:
                     config_data = {}
 
                 if config_data:
+                    config_data.update(config_overrides)
                     trie_root.insert(potential_config_file, config_data)
                     break
 


### PR DESCRIPTION
Without `--resolve-all-configs`, isort merges the options provided on the command line with the options found in config files. However this behavior is broken when `--resolve-all-configs` is specified. This change fixes that issue.