### PR TITLE
Updated docs for pre commit to fix bug with previous versions of isort

### DIFF
--- a/docs/configuration/pre-commit.md
+++ b/docs/configuration/pre-commit.md
@@ -9,7 +9,7 @@ To use isort's official pre-commit integration add the following config:
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
@@ -20,7 +20,7 @@ over different file types (ex: python vs cython vs pyi) you can do so with the f
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
Using the current example in the documentation leads to an error.

Also, it seems like [https://pycqa.github.io/isort/docs/configuration/pre-commit.html](https://pycqa.github.io/isort/docs/configuration/pre-commit.html) is not updating correctly. it still has an older version on the page compared to the file i modified.

#2108 

```
pre-commit installed at .git/hooks/pre-commit
[INFO] Installing environment for https://github.com/pycqa/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/root/.cache/pre-commit/repozmz4inly/py_env-python3.10/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /root/.cache/pre-commit/repozmz4inly
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'
stderr:
      error: subprocess-exited-with-error
      
      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [14 lines of output]
          Traceback (most recent call last):
            File "/root/.cache/pre-commit/repozmz4inly/py_env-python3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/root/.cache/pre-commit/repozmz4inly/py_env-python3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
            File "/root/.cache/pre-commit/repozmz4inly/py_env-python3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
              return hook(metadata_directory, config_settings)
            File "/tmp/pip-build-env-yyrljevj/overlay/lib/python3.10/site-packages/poetry/core/masonry/api.py", line 40, in prepare_metadata_for_build_wheel
              poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
            File "/tmp/pip-build-env-yyrljevj/overlay/lib/python3.10/site-packages/poetry/core/factory.py", line 57, in create_poetry
              raise RuntimeError("The Poetry configuration is invalid:\n" + message)
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
          
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed
    
    × Encountered error while generating package metadata.
    ╰─> See above for output.
    
    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
Check the log at /root/.cache/pre-commit/pre-commit.log
```