### PR TITLE
Fix profile black: missing split_on_trailing_comma=True

### DIFF
--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -8,6 +8,7 @@ black = {
     "use_parentheses": True,
     "ensure_newline_before_comments": True,
     "line_length": 88,
+    "split_on_trailing_comma": True,
 }
 django = {
     "combine_as_imports": True,


### PR DESCRIPTION
Came up in https://github.com/charliermarsh/ruff/issues/4153#issuecomment-1555986378.