### PR TITLE
Make src_paths behave as expected when using --resolve-all-configs and improve performance

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1758,7 +1758,7 @@ Explicitly set the config root for resolving all configs. When used with the --r
 
 ## Resolve All Configs
 
-Tells isort to resolve the configs for all sub-directories and sort files in terms of its closest config files.
+Tells isort to resolve the configs for all sub-directories and sort files in terms of its closest config files. When using this option, `src_paths` will resolve relative to the directory that contains the config that was used by default.
 
 **Type:** Bool  
 **Default:** `False`  

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1791,7 +1791,7 @@ Explicitly set the config root for resolving all configs. When used with the --r
 
 ## Resolve All Configs
 
-Tells isort to resolve the configs for all sub-directories and sort files in terms of its closest config files.
+Tells isort to resolve the configs for all sub-directories and sort files in terms of its closest config files. When using this option, `src_paths` will resolve relative to the directory that contains the config that was used by default.
 
 **Type:** Bool  
 **Default:** `False`  

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -19,6 +19,7 @@ from typing import (
     Dict,
     FrozenSet,
     Iterable,
+    Iterator,
     List,
     Optional,
     Pattern,
@@ -806,26 +807,41 @@ def find_all_configs(path: str) -> Trie:
     """
     trie_root = Trie("default", {})
 
-    for dirpath, _, _ in os.walk(path):
-        for config_file_name in CONFIG_SOURCES:
-            potential_config_file = os.path.join(dirpath, config_file_name)
-            if os.path.isfile(potential_config_file):
-                config_data: Dict[str, Any]
-                try:
-                    config_data = _get_config_data(
-                        potential_config_file, CONFIG_SECTIONS[config_file_name]
-                    )
-                except Exception:
-                    warn(f"Failed to pull configuration information from {potential_config_file}")
-                    config_data = {}
-
-                if config_data:
-                    if "directory" not in config_data:
-                        config_data["directory"] = dirpath
-                    trie_root.insert(potential_config_file, config_data)
-                    break
+    config_sources_set = set(CONFIG_SOURCES)
+    for potential_config_file in _scanwalk_files(
+        path, exclude_fn=lambda entry: entry.name in DEFAULT_SKIP
+    ):
+        if potential_config_file.name not in config_sources_set:
+            continue
+        try:
+            config_data = _get_config_data(
+                potential_config_file.path, CONFIG_SECTIONS[potential_config_file.name]
+            )
+            if "directory" not in config_data:
+                config_data["directory"] = os.path.dirname(potential_config_file.path)
+            trie_root.insert(potential_config_file.path, config_data)
+        except Exception:
+            warn(f"Failed to pull configuration information from {potential_config_file.path}")
 
     return trie_root
+
+
+def _scanwalk_files(
+    root_path: str, exclude_fn: Callable[[os.DirEntry], bool] = None
+) -> Iterator[os.DirEntry]:
+    # depth-first walk of file system starting with root_path
+    stack: List[str] = [root_path]
+    while stack:
+        dir_path = stack.pop()
+        with os.scandir(dir_path) as it:
+            for entry in it:
+                # Avoid processing excluded files/dirs and their descendants
+                if exclude_fn and exclude_fn(entry):
+                    continue
+                if entry.is_dir():
+                    stack.append(entry.path)
+                elif entry.is_file():
+                    yield entry
 
 
 def _get_config_data(file_path: str, sections: Tuple[str, ...]) -> Dict[str, Any]:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -820,6 +820,8 @@ def find_all_configs(path: str) -> Trie:
                     config_data = {}
 
                 if config_data:
+                    if "directory" not in config_data:
+                        config_data["directory"] = dirpath
                     trie_root.insert(potential_config_file, config_data)
                     break
 

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -11,7 +11,7 @@ import re
 import stat
 import subprocess  # nosec # Needed for gitignore support.
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import asdict, dataclass, field
 from importlib.metadata import EntryPoints
 from pathlib import Path
@@ -780,29 +780,48 @@ def find_all_configs(path: str) -> Trie:
     """
     trie_root = Trie("default", {})
 
-    for dirpath, _, _ in os.walk(path):
-        for config_file_name in CONFIG_SOURCES:
-            potential_config_file = os.path.join(dirpath, config_file_name)
-            if os.path.isfile(potential_config_file):
-                config_data: dict[str, Any]
-                try:
-                    config_data = _get_config_data(
-                        potential_config_file, CONFIG_SECTIONS[config_file_name]
-                    )
-                except Exception:
-                    warn(
-                        f"Failed to pull configuration information from {potential_config_file}",
-                        stacklevel=2,
-                    )
-                    config_data = {}
+    config_sources_set = set(CONFIG_SOURCES)
+    for potential_config_file in _scanwalk_files(
+        path, exclude_fn=lambda entry: entry.name in DEFAULT_SKIP
+    ):
+        if potential_config_file.name not in config_sources_set:
+            continue
+        config_data: dict[str, Any]
+        try:
+            config_data = _get_config_data(
+                potential_config_file.path, CONFIG_SECTIONS[potential_config_file.name]
+            )
+        except Exception:
+            warn(
+                f"Failed to pull configuration information from {potential_config_file.path}",
+                stacklevel=2,
+            )
+            config_data = {}
 
-                if config_data:
-                    if "directory" not in config_data:
-                        config_data["directory"] = dirpath
-                    trie_root.insert(potential_config_file, config_data)
-                    break
+        if config_data:
+            if "directory" not in config_data:
+                config_data["directory"] = os.path.dirname(potential_config_file.path)
+            trie_root.insert(potential_config_file.path, config_data)
 
     return trie_root
+
+
+def _scanwalk_files(
+    root_path: str, exclude_fn: Callable[[os.DirEntry[str]], bool] | None = None
+) -> Iterator[os.DirEntry[str]]:
+    # depth-first walk of file system starting with root_path
+    stack: list[str] = [root_path]
+    while stack:
+        dir_path = stack.pop()
+        with os.scandir(dir_path) as it:
+            for entry in it:
+                # Avoid processing excluded files/dirs and their descendants
+                if exclude_fn and exclude_fn(entry):
+                    continue
+                if entry.is_dir():
+                    stack.append(entry.path)
+                elif entry.is_file():
+                    yield entry
 
 
 def _get_config_data(file_path: str, sections: tuple[str, ...]) -> dict[str, object]:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -797,6 +797,8 @@ def find_all_configs(path: str) -> Trie:
                     config_data = {}
 
                 if config_data:
+                    if "directory" not in config_data:
+                        config_data["directory"] = dirpath
                     trie_root.insert(potential_config_file, config_data)
                     break
 

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -780,11 +780,22 @@ def find_all_configs(path: str) -> Trie:
     """
     trie_root = Trie("default", {})
 
-    config_sources_set = set(CONFIG_SOURCES)
+    # Precedence of config file names within a single directory. When a directory
+    # contains more than one config file, the one earliest in CONFIG_SOURCES wins,
+    # matching the behavior of scanning CONFIG_SOURCES in order. os.scandir yields
+    # entries in an arbitrary order, so we can't rely on encounter order.
+    config_source_priority = {name: index for index, name in enumerate(CONFIG_SOURCES)}
+    # Highest-priority config file already stored for each directory (lower is better).
+    chosen_priority_by_dir: dict[str, int] = {}
     for potential_config_file in _scanwalk_files(
         path, exclude_fn=lambda entry: entry.name in DEFAULT_SKIP
     ):
-        if potential_config_file.name not in config_sources_set:
+        priority = config_source_priority.get(potential_config_file.name)
+        if priority is None:
+            continue
+        dir_path = os.path.dirname(potential_config_file.path)
+        # A config file already chosen for this directory takes precedence.
+        if chosen_priority_by_dir.get(dir_path, len(CONFIG_SOURCES)) <= priority:
             continue
         config_data: dict[str, Any]
         try:
@@ -800,8 +811,9 @@ def find_all_configs(path: str) -> Trie:
 
         if config_data:
             if "directory" not in config_data:
-                config_data["directory"] = os.path.dirname(potential_config_file.path)
+                config_data["directory"] = dir_path
             trie_root.insert(potential_config_file.path, config_data)
+            chosen_priority_by_dir[dir_path] = priority
 
     return trie_root
 
@@ -813,15 +825,26 @@ def _scanwalk_files(
     stack: list[str] = [root_path]
     while stack:
         dir_path = stack.pop()
-        with os.scandir(dir_path) as it:
-            for entry in it:
-                # Avoid processing excluded files/dirs and their descendants
-                if exclude_fn and exclude_fn(entry):
-                    continue
-                if entry.is_dir():
+        try:
+            with os.scandir(dir_path) as it:
+                entries = list(it)
+        except OSError:
+            # Skip directories we can't read (permissions, broken links, etc.)
+            continue
+        for entry in entries:
+            # Avoid processing excluded files/dirs and their descendants
+            if exclude_fn and exclude_fn(entry):
+                continue
+            try:
+                # Don't recurse into symlinked directories, matching os.walk's
+                # default (followlinks=False), to avoid symlink loops.
+                if entry.is_dir(follow_symlinks=False):
                     stack.append(entry.path)
                 elif entry.is_file():
                     yield entry
+            except OSError:
+                # is_dir()/is_file() can raise for broken links; skip the entry.
+                continue
 
 
 def _get_config_data(file_path: str, sections: tuple[str, ...]) -> dict[str, object]:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -258,11 +258,13 @@ something = nothing
     dir2 = tmpdir / "subdir2"
     dir3 = tmpdir / "subdir3"
     dir4 = tmpdir / "subdir4"
+    dir_skip = tmpdir / ".venv"
 
     dir1.mkdir()
     dir2.mkdir()
     dir3.mkdir()
     dir4.mkdir()
+    dir_skip.mkdir()
 
     setup_cfg_file = dir1 / "setup.cfg"
     setup_cfg_file.write_text(setup_cfg, "utf-8")
@@ -275,6 +277,9 @@ something = nothing
 
     pyproject_toml_file_broken = dir4 / "pyproject.toml"
     pyproject_toml_file_broken.write_text(pyproject_toml_broken, "utf-8")
+
+    pyproject_toml_file_skip = dir_skip / "pyproject.toml"
+    pyproject_toml_file_skip.write_text(pyproject_toml, "utf-8")
 
     config_trie = settings.find_all_configs(str(tmpdir))
 
@@ -296,3 +301,7 @@ something = nothing
     config_info_4 = config_trie.search(str(tmpdir / "file4.py"))
     assert config_info_4[0] == "default"
     assert set(Config(**config_info_4[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}
+
+    config_info_skip = config_trie.search(str(dir_skip / "skip.py"))
+    assert config_info_skip[0] == "default"
+    assert set(Config(**config_info_skip[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -241,6 +241,7 @@ profile=django
     pyproject_toml = """
 [tool.isort]
 profile = "hug"
+src_paths = ["src"]
 """
 
     isort_cfg = """
@@ -280,14 +281,18 @@ something = nothing
     config_info_1 = config_trie.search(str(dir1 / "test1.py"))
     assert config_info_1[0] == str(setup_cfg_file)
     assert config_info_1[0] == str(setup_cfg_file) and config_info_1[1]["profile"] == "django"
+    assert set(Config(**config_info_1[1]).src_paths) == {Path(dir1), Path(dir1, "src")}
 
     config_info_2 = config_trie.search(str(dir2 / "test2.py"))
     assert config_info_2[0] == str(pyproject_toml_file)
     assert config_info_2[0] == str(pyproject_toml_file) and config_info_2[1]["profile"] == "hug"
+    assert set(Config(**config_info_2[1]).src_paths) == {Path(dir2, "src")}
 
     config_info_3 = config_trie.search(str(dir3 / "test3.py"))
     assert config_info_3[0] == str(isort_cfg_file)
     assert config_info_3[0] == str(isort_cfg_file) and config_info_3[1]["profile"] == "black"
+    assert set(Config(**config_info_3[1]).src_paths) == {Path(dir3), Path(dir3, "src")}
 
     config_info_4 = config_trie.search(str(tmpdir / "file4.py"))
     assert config_info_4[0] == "default"
+    assert set(Config(**config_info_4[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -304,6 +304,52 @@ something = nothing
     assert config_info_4[0] == "default"
     assert set(Config(**config_info_4[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}
 
+    # A config file that exists but has no valid isort section (dir4) is not
+    # inserted, so files under it fall back to the default config.
+    config_info_broken = config_trie.search(str(dir4 / "test4.py"))
+    assert config_info_broken[0] == "default"
+    assert set(Config(**config_info_broken[1]).src_paths) == {
+        Path.cwd(),
+        Path.cwd().joinpath("src"),
+    }
+
     config_info_skip = config_trie.search(str(dir_skip / "skip.py"))
     assert config_info_skip[0] == "default"
     assert set(Config(**config_info_skip[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}
+
+
+def test_find_all_configs_does_not_follow_symlink_loops(tmpdir):
+    # Regression: _scanwalk_files must not recurse into symlinked directories,
+    # which would otherwise loop forever on a cyclic symlink.
+    real_dir = tmpdir / "real"
+    real_dir.mkdir()
+    isort_cfg_file = real_dir / ".isort.cfg"
+    isort_cfg_file.write_text("[settings]\nprofile=black\n", "utf-8")
+
+    try:
+        os.symlink(str(tmpdir), str(tmpdir / "loop"))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not supported on this platform")
+
+    # Should terminate rather than looping through the symlink.
+    config_trie = settings.find_all_configs(str(tmpdir))
+
+    config_info = config_trie.search(str(real_dir / "test.py"))
+    assert config_info[0] == str(isort_cfg_file)
+    assert config_info[1]["profile"] == "black"
+
+
+def test_find_all_configs_respects_config_source_priority(tmpdir):
+    # A directory containing multiple config files resolves to the one with the
+    # highest precedence in CONFIG_SOURCES (.isort.cfg over setup.cfg), regardless
+    # of the order os.scandir happens to return them in.
+    isort_cfg_file = tmpdir / ".isort.cfg"
+    isort_cfg_file.write_text("[settings]\nprofile=black\n", "utf-8")
+    setup_cfg_file = tmpdir / "setup.cfg"
+    setup_cfg_file.write_text("[isort]\nprofile=django\n", "utf-8")
+
+    config_trie = settings.find_all_configs(str(tmpdir))
+
+    config_info = config_trie.search(str(tmpdir / "test.py"))
+    assert config_info[0] == str(isort_cfg_file)
+    assert config_info[1]["profile"] == "black"

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -240,6 +240,7 @@ profile=django
     pyproject_toml = """
 [tool.isort]
 profile = "hug"
+src_paths = ["src"]
 """
 
     isort_cfg = """
@@ -280,16 +281,20 @@ something = nothing
     assert config_info_1[0] == str(setup_cfg_file)
     assert config_info_1[0] == str(setup_cfg_file)
     assert config_info_1[1]["profile"] == "django"
+    assert set(Config(**config_info_1[1]).src_paths) == {Path(dir1), Path(dir1, "src")}
 
     config_info_2 = config_trie.search(str(dir2 / "test2.py"))
     assert config_info_2[0] == str(pyproject_toml_file)
     assert config_info_2[0] == str(pyproject_toml_file)
     assert config_info_2[1]["profile"] == "hug"
+    assert set(Config(**config_info_2[1]).src_paths) == {Path(dir2, "src")}
 
     config_info_3 = config_trie.search(str(dir3 / "test3.py"))
     assert config_info_3[0] == str(isort_cfg_file)
     assert config_info_3[0] == str(isort_cfg_file)
     assert config_info_3[1]["profile"] == "black"
+    assert set(Config(**config_info_3[1]).src_paths) == {Path(dir3), Path(dir3, "src")}
 
     config_info_4 = config_trie.search(str(tmpdir / "file4.py"))
     assert config_info_4[0] == "default"
+    assert set(Config(**config_info_4[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -257,11 +257,13 @@ something = nothing
     dir2 = tmpdir / "subdir2"
     dir3 = tmpdir / "subdir3"
     dir4 = tmpdir / "subdir4"
+    dir_skip = tmpdir / ".venv"
 
     dir1.mkdir()
     dir2.mkdir()
     dir3.mkdir()
     dir4.mkdir()
+    dir_skip.mkdir()
 
     setup_cfg_file = dir1 / "setup.cfg"
     setup_cfg_file.write_text(setup_cfg, "utf-8")
@@ -274,6 +276,9 @@ something = nothing
 
     pyproject_toml_file_broken = dir4 / "pyproject.toml"
     pyproject_toml_file_broken.write_text(pyproject_toml_broken, "utf-8")
+
+    pyproject_toml_file_skip = dir_skip / "pyproject.toml"
+    pyproject_toml_file_skip.write_text(pyproject_toml, "utf-8")
 
     config_trie = settings.find_all_configs(str(tmpdir))
 
@@ -298,3 +303,7 @@ something = nothing
     config_info_4 = config_trie.search(str(tmpdir / "file4.py"))
     assert config_info_4[0] == "default"
     assert set(Config(**config_info_4[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}
+
+    config_info_skip = config_trie.search(str(dir_skip / "skip.py"))
+    assert config_info_skip[0] == "default"
+    assert set(Config(**config_info_skip[1]).src_paths) == {Path.cwd(), Path.cwd().joinpath("src")}


### PR DESCRIPTION
When using `--resolve-all-configs`, there is unexpected behavior in that `src_paths` ends up resolving relative to the project root, which defaults to the current working directory. This results in first-party modules being marked as third-party modules in the default case.

Under the previous implementation, one possible workaround would be to specify the relative path to config directory (e.g. `relative/path/to/configdir/src`). However, assuming that the most common use of `--resolve-all-configs` is to support multiple sub-projects in the same repository/overall directory, this workaround would now require each sub-project to understand where it lives in the filesystem.

This change proposes a fix that sets `directory` on the `config_data` to be the directory containing the used configuration file if not already set. Downstream, this directory is then used to resolve the absolute paths specified by `src_paths`.

This change also introduces performance improvements to `find_all_configs` by pruning as we walk the filesystem and other smaller performance enhancements.

Fixes #2045