### PR TITLE
Add --exclude and --exclude-glob flags

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -126,6 +126,7 @@ Files that isort should skip over. To even skip matching files that have been sp
 
 - --sg
 - --skip-glob
+- --exclude
 
 **Examples:**
 
@@ -156,6 +157,7 @@ Additional files that isort should skip over (extending --skip-glob). To even sk
 **CLI Flags:**
 
 - --extend-skip-glob
+- --extend-exclude
 
 **Examples:**
 
@@ -172,6 +174,36 @@ extend_skip_glob=my_*_module.py,test/*
 ```
 [tool.isort]
 extend_skip_glob = ["my_*_module.py", "test/*"]
+
+```
+
+## Exclude Glob
+
+Files that isort should skip over. Paths are being excluded as globs. To even skip matching files that have been specified on the command line, use [`--filter-files`](#filter-files).
+
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** exclude-glob  
+**CLI Flags:**
+
+- --exclude-glob
+
+**Examples:**
+
+### Example `.isort.cfg`
+
+```
+[settings]
+exclude_glob=docs/**
+
+```
+
+### Example `pyproject.toml`
+
+```
+[tool.isort]
+exclude_glob = ["docs/**"]
 
 ```
 

--- a/isort/exceptions.py
+++ b/isort/exceptions.py
@@ -70,8 +70,8 @@ class FileSkipSetting(FileSkipped):
 
     def __init__(self, file_path: str, **kwargs: str):
         super().__init__(
-            f"{file_path} was skipped as it's listed in 'skip' setting"
-            " or matches a glob in 'skip_glob' setting",
+            f"{file_path} was skipped as it's listed in 'skip' setting, "
+            "matches in 'exclude' setting or matches a glob in 'exclude-glob'",
             file_path=file_path,
         )
 

--- a/isort/main.py
+++ b/isort/main.py
@@ -363,14 +363,22 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     target_group.add_argument(
         "--sg",
         "--skip-glob",
+        "--exclude",
         help="Files that isort should skip over.",
         dest="skip_glob",
         action="append",
     )
     target_group.add_argument(
         "--extend-skip-glob",
+        "--extend-exclude",
         help="Additional files that isort should skip over (extending --skip-glob).",
         dest="extend_skip_glob",
+        action="append",
+    )
+    target_group.add_argument(
+        "--exclude-glob",
+        help="Files that isort should skip over, In a glob notation.",
+        dest="exclude_glob",
         action="append",
     )
     target_group.add_argument(
@@ -1249,8 +1257,8 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
                 for was_skipped in skipped:
                     print(
                         f"{was_skipped} was skipped as it's listed in 'skip' setting, "
-                        "matches a glob in 'skip_glob' setting, or is in a .gitignore file with "
-                        "--skip-gitignore enabled."
+                        "matches in 'exclude' setting or matches a glob in 'exclude-glob', "
+                        "or is in a .gitignore file with --skip-gitignore enabled."
                     )
             print(f"Skipped {num_skipped} files")
 

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -147,6 +147,7 @@ class _Config:
     extend_skip: FrozenSet[str] = frozenset()
     skip_glob: FrozenSet[str] = frozenset()
     extend_skip_glob: FrozenSet[str] = frozenset()
+    exclude_glob: FrozenSet[str] = frozenset()
     skip_gitignore: bool = False
     line_length: int = 79
     wrap_length: int = 0
@@ -306,6 +307,7 @@ class Config(_Config):
         self._section_comments_end: Optional[Tuple[str, ...]] = None
         self._skips: Optional[FrozenSet[str]] = None
         self._skip_globs: Optional[FrozenSet[str]] = None
+        self._exclude_globs: Optional[FrozenSet[str]] = None
         self._sorting_function: Optional[Callable[..., List[str]]] = None
 
         if config:
@@ -317,6 +319,7 @@ class Config(_Config):
             config_vars.pop("_section_comments_end")
             config_vars.pop("_skips")
             config_vars.pop("_skip_globs")
+            config_vars.pop("_exclude_globs")
             config_vars.pop("_sorting_function")
             super().__init__(**config_vars)
             return
@@ -619,6 +622,10 @@ class Config(_Config):
             if fnmatch.fnmatch(file_name, sglob) or fnmatch.fnmatch("/" + file_name, sglob):
                 return True
 
+        for exclude_glob in self.exclude_globs:
+            if file_path in Path(self.directory).glob(exclude_glob):
+                return True
+
         if not (os.path.isfile(os_path) or os.path.isdir(os_path) or os.path.islink(os_path)):
             return True
 
@@ -702,6 +709,14 @@ class Config(_Config):
 
         self._skip_globs = self.skip_glob.union(self.extend_skip_glob)
         return self._skip_globs
+
+    @property
+    def exclude_globs(self) -> FrozenSet[str]:
+        if self._exclude_globs is not None:
+            return self._exclude_globs
+
+        self._exclude_globs = self.exclude_glob
+        return self._exclude_globs
 
     @property
     def sorting_function(self) -> Callable[..., List[str]]:

--- a/scripts/build_config_option_docs.py
+++ b/scripts/build_config_option_docs.py
@@ -167,6 +167,14 @@ extend_skip_glob=my_*_module.py,test/*
 extend_skip_glob = ["my_*_module.py", "test/*"]
 """,
     ),
+    "exclude_glob": Example(
+        cfg="""
+exclude_glob=docs/**
+""",
+        pyproject_toml="""
+exclude_glob = ["docs/**"]
+""",
+    ),
     "known_third_party": Example(
         cfg="""
 known_third_party=my_module1,my_module2

--- a/tests/integration/test_setting_combinations.py
+++ b/tests/integration/test_setting_combinations.py
@@ -181,6 +181,7 @@ else:  # 2.x
             }
         ),
         skip_glob=frozenset(),
+        exclude_glob=frozenset(),
         skip_gitignore=True,
         line_length=79,
         wrap_length=0,
@@ -615,6 +616,7 @@ else:  # 2.x
                     }
                 ),
                 "skip_glob": frozenset(),
+                "exclude_glob": frozenset(),
                 "skip_gitignore": False,
                 "line_length": 79,
                 "wrap_length": 0,
@@ -1046,6 +1048,7 @@ def test_isort_is_idempotent(config: isort.Config, disregard_skip: bool) -> None
             }
         ),
         skip_glob=frozenset(),
+        exclude_glob=frozenset(),
         skip_gitignore=True,
         line_length=79,
         wrap_length=0,
@@ -1480,6 +1483,7 @@ def test_isort_is_idempotent(config: isort.Config, disregard_skip: bool) -> None
                     }
                 ),
                 "skip_glob": frozenset(),
+                "exclude_glob": frozenset(),
                 "skip_gitignore": False,
                 "line_length": 79,
                 "wrap_length": 0,


### PR DESCRIPTION
Both _flake8_ and _black_ have `--exclude` flag which works the same as `--skip-glob` in _isort_.

This is highly confusing because `--skip-glob` isn't a real glob, and works using `fnmatch`.

aliasing `--exclude` to `--skip-glob` and creating new real glob option called `--exclude-glob` will make `isort` compatible with `--exclude` option in other utilities and add a new glob option if anyone really meant to use glob.

In my opinion, it is best to deprecate `--skip-glob` and replace it completely with `--exclude`, however I'm not sure what is the policy here for doing it.