### PR TITLE
docs(configuration/options.md): fix missing trailing spaces for hard linebreak

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -910,7 +910,7 @@ Split imports list followed by a trailing comma into VERTICAL_HANGING_INDENT mod
 **Type:** Bool  
 **Default:** `False`  
 **Config default:** `false`  
-**Python & Config File Name:** split_on_trailing_comma
+**Python & Config File Name:** split_on_trailing_comma  
 **CLI Flags:**
 
 - --split-on-trailing-comma


### PR DESCRIPTION
As far as I checked, this is the only place with the trailing spaces missing in this file.