### PR TITLE
docs: fix black profile documentation

### DIFF
--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -16,7 +16,6 @@ To use any of the listed profiles, use `isort --profile PROFILE_NAME` from the c
  - **use_parentheses**: `True`
  - **ensure_newline_before_comments**: `True`
  - **line_length**: `88`
- - **split_on_trailing_comma**: `True`
 
 #django
 


### PR DESCRIPTION
split_on_trailing_comma is not actually enabled by the black profile