### PR TITLE
Retry section lookup for from+import statements, if defaulted

### DIFF
--- a/isort/deprecated/finders.py
+++ b/isort/deprecated/finders.py
@@ -377,12 +377,12 @@ class FindersManager:
                     )
         self.finders: Tuple[BaseFinder, ...] = tuple(finders)
 
-    def find(self, module_name: str) -> Optional[str]:
+    def find(self, module_name: str) -> Tuple[Optional[str], str]:
         for finder in self.finders:
             try:
                 section = finder.find(module_name)
                 if section is not None:
-                    return section
+                    return section, ""
             except Exception as exception:
                 # isort has to be able to keep trying to identify the correct
                 # import section even if one approach fails
@@ -391,4 +391,4 @@ class FindersManager:
                         f"{finder.__class__.__name__} encountered an error ({exception}) while "
                         f"trying to identify the {module_name} module"
                     )
-        return None
+        return None, ""

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5671,3 +5671,14 @@ def test_reexport_not_last_line() -> None:
     meme = "rickroll"
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_import_submodule_both_ways() -> None:
+    """See https://github.com/PyCQA/isort/issues/2167."""
+    test_input = "import requests\n" "\n" "from subdir import fileA\n"
+    test_output = isort.code(code=test_input, known_first_party=["subdir.fileA"])
+    assert test_output == ("import requests\n" "\n" "from subdir import fileA\n")
+
+    test_input = "import requests\n" "\n" "import subdir.fileA\n"
+    test_output = isort.code(code=test_input, known_first_party=["subdir.fileA"])
+    assert test_output == ("import requests\n" "\n" "import subdir.fileA\n")


### PR DESCRIPTION
Fixes https://github.com/PyCQA/isort/issues/2167 by issuing a second call to `finder()` using the joined parts of the `from X import Y` in case `Y` is a submodule, and `X.Y` was specified in a section. The second call is only issued if we match the default section with a default reasoning, so this should be fully backwards-compatible.

