### PR TITLE
Fix 80 line length for `wemake` linter

### DIFF
--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -61,7 +61,7 @@ wemake = {
     "multi_line_output": 3,
     "include_trailing_comma": True,
     "use_parentheses": True,
-    "line_length": 80,
+    "line_length": 79,
 }
 appnexus = {
     **black,

--- a/tests/unit/profiles/test_wemake.py
+++ b/tests/unit/profiles/test_wemake.py
@@ -85,3 +85,23 @@ from wemake_python_styleguide.transformations.ast.enhancements import (
 class _ClassVisitor(ast.NodeVisitor): ...
 """
     )
+
+
+def test_wemake_snippet_four():
+    """80 line length should be fixed"""
+    wemake_isort_test(
+        """
+from typing import Iterable, Iterator, Optional, Sequence, Tuple, TypeVar, Union
+""",
+        """
+from typing import (
+    Iterable,
+    Iterator,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
+""",
+    )


### PR DESCRIPTION
[Root issue](https://github.com/PyCQA/isort/issues/2182)
Fixed the line length for `wemake` profile to be 79 to comply with linter.
Wrote negative test