### PR TITLE
Fix assertions in `test_git_hook`

### DIFF
--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -11,7 +11,7 @@ def test_git_hook(src_dir):
     # Ensure correct subprocess command is called
     with patch("subprocess.run", MagicMock()) as run_mock:
         hooks.git_hook()
-        assert run_mock.called_once()
+        run_mock.assert_called_once()
         assert run_mock.call_args[0][0] == [
             "git",
             "diff-index",
@@ -21,8 +21,9 @@ def test_git_hook(src_dir):
             "HEAD",
         ]
 
+    with patch("subprocess.run", MagicMock()) as run_mock:
         hooks.git_hook(lazy=True)
-        assert run_mock.called_once()
+        run_mock.assert_called_once()
         assert run_mock.call_args[0][0] == [
             "git",
             "diff-index",


### PR DESCRIPTION
Fix `called_once()` assertions in `test_git_hook` to use the correct `assert_called_once()` method.  The former does not exist, so it evaluates to a mocked method in Python < 3.12, making the assert meaningless, and it triggers an error in Python 3.12+.

While at it, split the mock into two because otherwise the test would fail because two `hooks.git_hook()` calls imply two mock calls.