### PR TITLE
Update pre-commit.md version number

### DIFF
--- a/docs/configuration/pre-commit.md
+++ b/docs/configuration/pre-commit.md
@@ -20,7 +20,7 @@ over different file types (ex: python vs cython vs pyi) you can do so with the f
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
Small PR fixing the isort version number in [pre-commit documentation page](https://pycqa.github.io/isort/docs/configuration/pre-commit.html)