### PR TITLE
Add exception handling for missing isort package metadata

### DIFF
--- a/isort/_version.py
+++ b/isort/_version.py
@@ -1,3 +1,7 @@
 from importlib import metadata
 
-__version__ = metadata.version("isort")
+try:
+	__version__ = metadata.version("isort")
+except metadata.PackageNotFoundError:
+	# Case where isort package metadata is not available.
+	__version__ = ""

--- a/isort/_version.py
+++ b/isort/_version.py
@@ -1,7 +1,7 @@
 from importlib import metadata
 
 try:
-	__version__ = metadata.version("isort")
+    __version__ = metadata.version("isort")
 except metadata.PackageNotFoundError:
-	# Case where isort package metadata is not available.
-	__version__ = ""
+    # Case where isort package metadata is not available.
+    __version__ = ""


### PR DESCRIPTION
This commit introduces a try-except block to handle the scenario where the isort package metadata is not available. In such cases, instead of raising an error, the __version__ variable is set to an empty string.