### PR TITLE
Drop deprecated pytest.warns(None)

### DIFF
--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -3,6 +3,7 @@ it fully works as defined in the associated ticket.
 """
 from functools import partial
 from io import StringIO
+import warnings
 
 import pytest
 
@@ -615,9 +616,9 @@ quiet = true
 quiet = true
 """
     )
-    with pytest.warns(None) as warning:  # type: ignore
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         assert Config(settings_file=str(settings_file)).quiet
-    assert not warning
 
 
 def test_float_to_top_should_respect_existing_newlines_between_imports_issue_1502():


### PR DESCRIPTION
With Pytest 7:

https://docs.pytest.org/en/stable/changelog.html#pytest-7-0-0rc1-2021-12-06

> #8645: pytest.warns(None) is now deprecated because many people used
  it to mean “this code does not emit warnings”, but it actually had the
  effect of checking that the code emits at least one warning of any
  type-like pytest.warns() or pytest.warns(Warning)

With Pytest 8 it's the error.

Changed according to the documentation:
https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests

Fixes: https://github.com/PyCQA/isort/issues/2234