### PR TITLE
Black profile: enable magic comma

### DIFF
--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -12,6 +12,7 @@ To use any of the listed profiles, use `isort --profile PROFILE_NAME` from the c
 
  - **multi_line_output**: `3`
  - **include_trailing_comma**: `True`
+ - **split_on_trailing_comma**: `True`
  - **force_grid_wrap**: `0`
  - **use_parentheses**: `True`
  - **ensure_newline_before_comments**: `True`

--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 black = {
     "multi_line_output": 3,
     "include_trailing_comma": True,
+    "split_on_trailing_comma": True,
     "force_grid_wrap": 0,
     "use_parentheses": True,
     "ensure_newline_before_comments": True,

--- a/tests/unit/profiles/test_black.py
+++ b/tests/unit/profiles/test_black.py
@@ -447,3 +447,16 @@ def sub(a: np.ndarray, b: np.ndarray) -> np.ndarray: ...
         lines_before_imports=2,  # will be ignored
         lines_after_imports=2,  # will be ignored
     )
+
+
+def test_black_trailing_comma():
+    black_test(
+    "from x import (a, b, c,)\n",
+    """\
+from x import (
+    a,
+    b,
+    c,
+)
+""",
+    )


### PR DESCRIPTION
When `black` encounters a trailing comma in the `from ... import` list, it expands it vertically. Currently, `isort --profile=black` doesn't do that, which confuses people (including me :)), see #2128.

This PR enables `split_on_trailing_comma`, which is the default Black's behavior.

_I wasn't sure if I should create a new changelog version header, so i omitted it, since that would require deciding whether this is PATCH or MINOR._

---

What Black does:

```
$ echo "from x import (a, b, c,)" | black -

from x import (
    a,
    b,
    c,
)
reformatted -

All done! ✨ 🍰 ✨
1 file reformatted.
```

What isort does _currently_:

```
$ echo "from x import (a, b, c,)" | isort --profile=black -

from x import a, b, c
```

After this change:

```
$ echo "from x import (a, b, c,)" | isort --profile=black -

from x import (
    a,
    b,
    c,
)
```