### PR TITLE
Ignore `bandit`'s CVE reported by `safety`

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,5 +7,5 @@ poetry run black --target-version py38 --check .
 poetry run isort --profile hug --check --diff isort/ tests/
 poetry run isort --profile hug --check --diff example_*/
 poetry run flake8 isort/ tests/
-poetry run safety check -i 51457 -i 59587 # https://github.com/tiangolo/typer/discussions/674
+poetry run safety check -i 51457 -i 59587 -i 64484 # https://github.com/tiangolo/typer/discussions/674
 poetry run bandit -r isort/ -x isort/_vendored


### PR DESCRIPTION
It is a dev-dependency and there's no real vulnerability. This is why a job in my CI fails: https://github.com/PyCQA/isort/pull/2241

Link to CVE: https://data.safetycli.com/v/64484/f17

Or you can bump `bandit` to 1.7.8: https://pypi.org/project/bandit/1.7.8/