### PR TITLE
Added _collections_abc to standard library modules

### DIFF
--- a/scripts/mkstdlibs.py
+++ b/scripts/mkstdlibs.py
@@ -37,7 +37,7 @@ for version_info in VERSIONS:
     invdata = fetch_inventory(FakeApp(), "", url)
 
     # Any modules we want to enforce across Python versions stdlib can be included in set init
-    modules = {"_ast", "posixpath", "ntpath", "sre_constants", "sre_parse", "sre_compile", "sre"}
+    modules = {"_ast", "posixpath", "ntpath", "sre_constants", "sre_parse", "sre_compile", "sre", "_collections_abc"}
     for module in invdata["py:module"]:
         root, *_ = module.split(".")
         if root not in ["__future__", "__main__"]:

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5671,3 +5671,19 @@ def test_reexport_not_last_line() -> None:
     meme = "rickroll"
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_collections_abc() -> None:
+     test_input = (
+        "from typing import Iterable, Iterator, TypeVar, cast\n"
+        "\n"
+        "from _collections_abc import dict_items, dict_keys, dict_values\n"
+        "from python_none_objects import NoneIterable\n"
+    )
+     expd_output = (
+    "from typing import Iterable, Iterator, TypeVar, cast\n"
+    "from _collections_abc import dict_items, dict_keys, dict_values\n"
+    "\n"
+    "from python_none_objects import NoneIterable\n"
+      )
+     assert isort.code(test_input) == expd_output


### PR DESCRIPTION
This PR fixes issue #2250 by adding _collections_abc to the known standard library modules in mkstdlibs.py.