### PR TITLE
Fix `sort_reexports` code mangling

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -27,6 +27,8 @@ CODE_SORT_COMMENTS = (
 LITERAL_TYPE_MAPPING = {"(": "tuple", "[": "list", "{": "set"}
 
 
+# Ignore DeepSource cyclomatic complexity check for this function.
+# skipcq: PY-R1000
 def process(
     input_stream: TextIO,
     output_stream: TextIO,

--- a/isort/core.py
+++ b/isort/core.py
@@ -152,6 +152,8 @@ def process(
                     ignore_whitespace=config.ignore_whitespace,
                 )
                 output_stream.write(sorted_code)
+                if is_reexport:
+                    output_stream.truncate()
         else:
             stripped_line = line.strip()
             if stripped_line and not line_separator:
@@ -260,6 +262,8 @@ def process(
                             output_stream.seek(output_stream.tell() - reexport_rollback)
                             reexport_rollback = 0
                         output_stream.write(sorted_code)
+                        if is_reexport:
+                            output_stream.truncate()
                         not_imports = True
                         code_sorting = False
                         code_sorting_section = ""

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5727,26 +5727,3 @@ __all__ = ['bar', 'foo']
 test
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
-
-
-def test_reexport_black() -> None:
-    test_input = """from m import (
-    bar,
-    foo,
-)
-__all__ = [
-    "foo",
-    "bar",
-]
-
-test
-"""
-    expd_output = """from m import bar, foo
-
-__all__ = ["bar", "foo"]
-
-test
-"""
-    assert (
-        isort.code(test_input, config=Config(sort_reexports=True, profile="black")) == expd_output
-    )

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -2,6 +2,7 @@
 
 Should be ran using py.test by simply running py.test in the isort project directory
 """
+
 import os
 import os.path
 import subprocess
@@ -5671,3 +5672,81 @@ def test_reexport_not_last_line() -> None:
     meme = "rickroll"
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_reexport_multiline_import() -> None:
+    test_input = """from m import (
+    bar,
+    foo,
+)
+__all__ = [
+    "foo",
+    "bar",
+]
+"""
+    expd_output = """from m import bar, foo
+
+__all__ = ['bar', 'foo']
+"""
+    assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_reexport_multiline_in_center() -> None:
+    test_input = """from m import (
+    bar,
+    foo,
+) 
+__all__ = [
+    "foo",
+    "bar",
+]
+
+test
+"""
+    expd_output = """from m import bar, foo
+
+__all__ = ['bar', 'foo']
+
+test
+"""
+    assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_reexport_multiline_long_rollback() -> None:
+    test_input = """from m import foo, bar 
+__all__ = [                            "foo",
+    "bar",
+]
+
+test
+"""
+    expd_output = """from m import bar, foo
+
+__all__ = ['bar', 'foo']
+
+test
+"""
+    assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_reexport_black() -> None:
+    test_input = """from m import (
+    bar,
+    foo,
+)
+__all__ = [
+    "foo",
+    "bar",
+]
+
+test
+"""
+    expd_output = """from m import bar, foo
+
+__all__ = ["bar", "foo"]
+
+test
+"""
+    assert (
+        isort.code(test_input, config=Config(sort_reexports=True, profile="black")) == expd_output
+    )


### PR DESCRIPTION
Fixes #2193 and fixes #2252,

The logic behind `sort_reexports` was keeping track of a point in the `output_stream`, and seeked to that point before writing the sorted reexports back in, in order to compensate for the first line of this code sorting section being written into the stream already.

The original code tried to track the position of the point with every iteration, but since the code is very branched, and contains ~10 `.write` statements, this fails, and this approach would never be easily maintained. So I opted to simplify the approach by instead rolling back the write position in the stream by the length of the segment that was written too much.

Additionally, when the input code sort section is longer than the sorted output (e.g., when there is a lot of trimmed whitespace), some previously written garbage remained, which I fixed by truncating the stream after writing to it during `sort_reexport` operations.