### PR TITLE
fix: CLI --src flag glob patterns

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1116,9 +1116,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
         config_trie = find_all_configs(config_dict.pop("config_root", "."))
 
     if "src_paths" in config_dict:
-        config_dict["src_paths"] = {
-            Path(src_path).resolve() for src_path in config_dict.get("src_paths", ())
-        }
+        config_dict["src_paths"] = set(config_dict.get("src_paths", ()))
 
     config = Config(**config_dict)
     if show_config:


### PR DESCRIPTION
# Context

Resolves #2001.
A set is created with the resolved paths to avoid multiplicity, but paths can't be used as glob expressions, so the code fails when initializing the `Config` instance.
Given that there is logic to keep the src paths unique after evaluating them, the changes fix the bug harmlessly.

# Overview

* Change the type of the config value `"src_paths"` from `pathlib.Path` to `str`.
