### PR TITLE
Fixed syntax error

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -51,7 +51,7 @@ DEPRECATED_SINGLE_DASH_ARGS = {
 QUICK_GUIDE = f"""
 {ASCII_ART}
 
-Nothing to do: no files or paths have have been passed in!
+Nothing to do: no files or paths have been passed in!
 
 Try one of the following:
 


### PR DESCRIPTION
The word "have" is repeated twice in sentence:
Nothing to do: no files or paths have have been passed in!

This error has been fixed.