### PR TITLE
Update stage names for `pre-commit`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,9 @@
 -   id: isort
     name: isort
     entry: isort
-    stages: [commit, merge-commit, push, manual]
+    stages: [pre-commit, pre-merge-commit, pre-push, manual]
     require_serial: true
     language: python
     types_or: [cython, pyi, python]
     args: ['--filter-files']
-    minimum_pre_commit_version: '2.9.2'
+    minimum_pre_commit_version: '3.2.0'


### PR DESCRIPTION
`pre-commit` v4.0.0 added a warning to deprecated stage names[1] so update these names to avoid the warning. This also required updating the minimum `pre-commit` version to one that supports the new names

See also[2] for a similar change and the docs[3].

[1] https://github.com/pre-commit/pre-commit/blob/cc4a52241565440ce200666799eef70626457488/CHANGELOG.md#400---2024-10-05
[2] https://github.com/pre-commit/pre-commit-hooks/commit/003dfa55c9eb05b08b33f60864363392958f4618
[3] https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

Fixes: https://github.com/PyCQA/isort/issues/2294