### PR TITLE
feat: add dependabot for GH action update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
### Advantage

Dependabot can automatically look for updated GH actions and rise a PR.

Since dependabot can be very annoying and spam a lot of PRs the GH actions related PRs are grouped into one single PR. Also the update frequency is limited to monthly.

### Reference

#2299