### PR TITLE
Add separate_packages option

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1039,6 +1039,16 @@ If `True` isort will automatically create section groups by the top-level packag
 **Python & Config File Name:** group_by_package  
 **CLI Flags:** **Not Supported**
 
+## Separate Packages
+
+Separate packages within the listed sections with newlines.
+
+**Type:** List of Strings  
+**Default:** `frozenset()`  
+**Config default:** `[]`  
+**Python & Config File Name:** separate_packages  
+**CLI Flags:** **Not Supported**
+
 ## Ignore Whitespace
 
 Tells isort to ignore whitespace differences when --check-only is being used.

--- a/isort/output.py
+++ b/isort/output.py
@@ -151,9 +151,9 @@ def sorted_imports(
                     section_output.append(section_comment_end)
 
             if section in config.separate_packages:
-                group_keys: set[str] = set()
-                comments_above: list[str] = []
-                processed_section_output: list[str] = []
+                group_keys: Set[str] = set()
+                comments_above: List[str] = []
+                processed_section_output: List[str] = []
                 for section_line in section_output:
                     if section_line.startswith("#"):
                         comments_above.append(section_line)

--- a/isort/output.py
+++ b/isort/output.py
@@ -8,6 +8,7 @@ from isort.format import format_simplified
 from . import parse, sorting, wrap
 from .comments import add_to_line as with_comments
 from .identify import STATEMENT_DECLARATIONS
+from .place import module_with_reason
 from .settings import DEFAULT_CONFIG, Config
 
 
@@ -148,6 +149,38 @@ def sorted_imports(
                 ):  # pragma: no branch
                     section_output.append("")  # Empty line for black compatibility
                     section_output.append(section_comment_end)
+
+            if section in config.separate_packages:
+                group_keys: set[str] = set()
+                comments_above: list[str] = []
+                processed_section_output: list[str] = []
+                for section_line in section_output:
+                    if section_line.startswith("#"):
+                        comments_above.append(section_line)
+                        continue
+
+                    package_name: str = section_line.split(" ")[1]
+                    _, reason = module_with_reason(package_name, config)
+
+                    if "Matched configured known pattern" in reason:
+                        package_depth = len(reason.split(".")) - 1  # minus 1 for re.compile
+                        key = ".".join(package_name.split(".")[: package_depth + 1])
+                    else:
+                        key = package_name.split(".")[0]
+
+                    if key not in group_keys:
+                        if group_keys:
+                            processed_section_output.append("")
+
+                        group_keys.add(key)
+
+                    if comments_above:
+                        processed_section_output.extend(comments_above)
+                        comments_above = []
+
+                    processed_section_output.append(section_line)
+
+                section_output = processed_section_output
 
             if pending_lines_before or not no_lines_before:
                 output += [""] * config.lines_between_sections

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -200,6 +200,7 @@ class _Config:
     force_sort_within_sections: bool = False
     lexicographical: bool = False
     group_by_package: bool = False
+    separate_packages: FrozenSet[str] = frozenset()
     ignore_whitespace: bool = False
     no_lines_before: FrozenSet[str] = frozenset()
     no_inline_sort: bool = False


### PR DESCRIPTION
Resolves https://github.com/PyCQA/isort/issues/2104 by adding a separate_packages config option.

Sections provided in this field will have the packages within them be separated by a blank line. This also works with custom known_OTHER sections; see tests for examples.