### PR TITLE
Run `pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort

--- a/docs/configuration/black_compatibility.md
+++ b/docs/configuration/black_compatibility.md
@@ -56,8 +56,8 @@ See [built-in profiles](https://pycqa.github.io/isort/docs/configuration/profile
 You can also set the profile directly when integrating isort within pre-commit.
 
 ```yaml
-- repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/docs/upgrade_guides/5.0.0.md
+++ b/docs/upgrade_guides/5.0.0.md
@@ -82,7 +82,7 @@ isort now includes an optimized precommit configuration in the repo itself. To u
 
 ```
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
This commit introduces the following changes:

* Run `pre-commit autoupdate`
* Run `pre-commit run -a` (no changes made)
* Update pre-commit config examples to point to latest version
* Fix a YAML formatting issue in a pre-commit config example

@DanielNoord I'd like to recommend some changes to the pre-commit and linting usage based on these problem points:

* A script, `scripts/lint.sh`, is used to run linters.

  This is a manual step that can be missed by PR submitters. It requires users to correctly set up their own virtual environments with all of the correct tools, and excludes Windows users.

* The script runs in CI, but doesn't fix incoming PRs.

  This means that users must wait for approval to run the GitHub workflows before finding out that a linter is failing.

If you're open to it, I'll submit a PR to migrate some of the linters to the pre-commit config (like black and flake8). However, I recommend enabling pre-commit.ci for this repo; if that's desirable, I'll submit a PR to configure pre-commit.ci to check for hook updates on a quarterly basis.