### PR TITLE
Allow single-line imports from collections.abc in Google profile

### DIFF
--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -25,7 +25,7 @@ google = {
     "force_single_line": True,
     "force_sort_within_sections": True,
     "lexicographical": True,
-    "single_line_exclusions": ("typing",),
+    "single_line_exclusions": ("collections.abc", "typing"),
     "order_by_type": False,
     "group_by_package": True,
 }


### PR DESCRIPTION
Due to [paragraph 3.13](https://google.github.io/styleguide/pyguide.html#313-imports-formatting) in Google style guide, `collections.abc` is an exception for single-line imports rule.