### PR TITLE
Ensure that split_on_trailing_comma works with `as` imports

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -509,7 +509,7 @@ def _with_from_imports(
                 ):
                     do_multiline_reformat = True
 
-                if config.split_on_trailing_comma and module in parsed.trailing_commas:
+                if import_statement and config.split_on_trailing_comma and module in parsed.trailing_commas:
                     import_statement = wrap.import_statement(
                         import_start=import_start,
                         from_imports=from_import_section,

--- a/isort/output.py
+++ b/isort/output.py
@@ -509,7 +509,11 @@ def _with_from_imports(
                 ):
                     do_multiline_reformat = True
 
-                if import_statement and config.split_on_trailing_comma and module in parsed.trailing_commas:
+                if (
+                    import_statement
+                    and config.split_on_trailing_comma
+                    and module in parsed.trailing_commas
+                ):
                     import_statement = wrap.import_statement(
                         import_start=import_start,
                         from_imports=from_import_section,

--- a/isort/output.py
+++ b/isort/output.py
@@ -239,7 +239,9 @@ def sorted_imports(
 
     return _output_as_string(formatted_output, parsed.line_separator)
 
-
+# Ignore DeepSource cyclomatic complexity check for this function. It was
+# already complex when this check was enabled. 
+# skipcq: PY-R1000
 def _with_from_imports(
     parsed: parse.ParsedContent,
     config: Config,

--- a/isort/output.py
+++ b/isort/output.py
@@ -239,8 +239,9 @@ def sorted_imports(
 
     return _output_as_string(formatted_output, parsed.line_separator)
 
+
 # Ignore DeepSource cyclomatic complexity check for this function. It was
-# already complex when this check was enabled. 
+# already complex when this check was enabled.
 # skipcq: PY-R1000
 def _with_from_imports(
     parsed: parse.ParsedContent,

--- a/tests/integration/test_projects_using_isort.py
+++ b/tests/integration/test_projects_using_isort.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from subprocess import check_call
 from typing import Generator, Sequence
 
+import pytest
+
 from isort.main import main
 
 
@@ -26,6 +28,10 @@ def run_isort(arguments: Generator[str, None, None] | Sequence[str]):
     main(["--check-only", "--diff", *arguments])
 
 
+@pytest.mark.xfail(
+    reason="Project is incorrectly formatted after PR #2236, should be fixed "
+    "after a release and the project formatting again."
+)
 def test_django(tmpdir):
     git_clone("https://github.com/django/django.git", tmpdir)
     run_isort(

--- a/tests/unit/profiles/test_black.py
+++ b/tests/unit/profiles/test_black.py
@@ -447,8 +447,8 @@ def sub(a: np.ndarray, b: np.ndarray) -> np.ndarray: ...
 
 def test_black_trailing_comma():
     black_test(
-    "from x import (a, b, c,)\n",
-    """\
+        "from x import (a, b, c,)\n",
+        """\
 from x import (
     a,
     b,

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5587,6 +5587,7 @@ def test_split_on_trailing_comma_wih_as() -> None:
     output = isort.code(expected_output, split_on_trailing_comma=True)
     assert output == expected_output
 
+
 def test_infinite_loop_in_unmatched_parenthesis() -> None:
     test_input = "from os import ("
 

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5576,6 +5576,17 @@ def test_split_on_trailing_comma() -> None:
     assert output == expected_output
 
 
+def test_split_on_trailing_comma_wih_as() -> None:
+    test_input = "from lib import (a as b,)"
+    expected_output = """from lib import a as b
+"""
+
+    output = isort.code(test_input, split_on_trailing_comma=True)
+    assert output == expected_output
+
+    output = isort.code(expected_output, split_on_trailing_comma=True)
+    assert output == expected_output
+
 def test_infinite_loop_in_unmatched_parenthesis() -> None:
     test_input = "from os import ("
 


### PR DESCRIPTION
Closes https://github.com/PyCQA/isort/issues/2338

Took the tests as recommended in https://github.com/PyCQA/isort/pull/2339

I don't think we should fix the tests by disabling the new profile flag, that would mean that our tests work but anybody using the profile would still get broken imports.
Instead, let's try to fix `config.split_on_trailing_comma` itself. I believe this does this.