### PR TITLE
Apply some ruff rules

### DIFF
--- a/isort/deprecated/finders.py
+++ b/isort/deprecated/finders.py
@@ -236,10 +236,9 @@ class ReqsBaseFinder(BaseFinder):
 
     def _load_names(self) -> List[str]:
         """Return list of thirdparty modules from requirements"""
-        names = []
+        names: List[str] = []
         for path in self._get_files():
-            for name in self._get_names(path):
-                names.append(self._normalize_name(name))
+            names.extend(self._normalize_name(name) for name in self._get_names(path))
         return names
 
     @staticmethod
@@ -298,7 +297,7 @@ class RequirementsFinder(ReqsBaseFinder):
     @classmethod
     @lru_cache(maxsize=16)
     def _get_files_from_dir_cached(cls, path: str) -> List[str]:
-        results = []
+        results: List[str] = []
 
         for fname in os.listdir(path):
             if "requirements" not in fname:
@@ -308,9 +307,11 @@ class RequirementsFinder(ReqsBaseFinder):
             # *requirements*/*.{txt,in}
             if os.path.isdir(full_path):
                 for subfile_name in os.listdir(full_path):
-                    for ext in cls.exts:
-                        if subfile_name.endswith(ext):
-                            results.append(os.path.join(full_path, subfile_name))
+                    results.extend(
+                        os.path.join(full_path, subfile_name)
+                        for ext in cls.ext  # type: ignore[attr-defined]
+                        if subfile_name.endswith(ext)
+                    )
                 continue
 
             # *requirements*.{txt,in}
@@ -329,13 +330,11 @@ class RequirementsFinder(ReqsBaseFinder):
     @classmethod
     @lru_cache(maxsize=16)
     def _get_names_cached(cls, path: str) -> List[str]:
-        result = []
+        result: List[str] = []
 
         with chdir(os.path.dirname(path)):
             requirements = parse_requirements(Path(path))
-            for req in requirements.values():
-                if req.name:
-                    result.append(req.name)
+            result.extend(req.name for req in requirements.values() if req.name)
 
         return result
 

--- a/isort/identify.py
+++ b/isort/identify.py
@@ -61,7 +61,7 @@ def imports(
             continue
 
         stripped_line = raw_line.strip().split("#")[0]
-        if stripped_line.startswith("raise") or stripped_line.startswith("yield"):
+        if stripped_line.startswith(("raise", "yield")):
             if stripped_line == "yield":
                 while not stripped_line or stripped_line == "yield":
                     try:

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -96,7 +96,7 @@ def _list(value: List[Any], printer: ISortPrettyPrinter) -> str:
 
 @register_type("unique-list", list)
 def _unique_list(value: List[Any], printer: ISortPrettyPrinter) -> str:
-    return printer.pformat(list(sorted(set(value))))
+    return printer.pformat(sorted(set(value)))
 
 
 @register_type("set", set)

--- a/isort/main.py
+++ b/isort/main.py
@@ -876,7 +876,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--python-version",
         action="store",
         dest="py_version",
-        choices=tuple(VALID_PY_TARGETS) + ("auto",),
+        choices=(*tuple(VALID_PY_TARGETS), "auto"),
         help="Tells isort to set the known standard library based on the specified Python "
         "version. Default is to assume any Python 3 version could be the target, and use a union "
         "of all stdlib modules across versions. If auto is specified, the version of the "

--- a/isort/output.py
+++ b/isort/output.py
@@ -41,7 +41,7 @@ def sorted_imports(
                 parsed.imports[section].get("straight", {})
             )
             parsed.imports["no_sections"]["from"].update(parsed.imports[section].get("from", {}))
-        sections = base_sections + ("no_sections",)
+        sections = (*base_sections, "no_sections")
 
     output: List[str] = []
     seen_headings: Set[str] = set()
@@ -338,7 +338,7 @@ def _with_from_imports(
                     )
                     if comment:
                         single_import_line += (
-                            f"{comments and ';' or config.comment_prefix} " f"{comment}"
+                            f"{(comments and ';') or config.comment_prefix} " f"{comment}"
                         )
                     if from_import in as_imports:
                         if (
@@ -467,7 +467,7 @@ def _with_from_imports(
                             comment_prefix=config.comment_prefix,
                         )
                         single_import_line += (
-                            f"{use_comments and ';' or config.comment_prefix} " f"{comment}"
+                            f"{(use_comments and ';') or config.comment_prefix} " f"{comment}"
                         )
                         output.append(wrap.line(single_import_line, parsed.line_separator, config))
 
@@ -662,7 +662,7 @@ def _ensure_newline_before_comment(output: List[str]) -> List[str]:
     def is_comment(line: Optional[str]) -> bool:
         return line.startswith("#") if line else False
 
-    for line, prev_line in zip(output, [None] + output):  # type: ignore
+    for line, prev_line in zip(output, [None, *output]):
         if is_comment(line) and prev_line != "" and not is_comment(prev_line):
             new_output.append("")
         new_output.append(line)
@@ -672,5 +672,5 @@ def _ensure_newline_before_comment(output: List[str]) -> List[str]:
 def _with_star_comments(parsed: parse.ParsedContent, module: str, comments: List[str]) -> List[str]:
     star_comment = parsed.categorized_comments["nested"].get(module, {}).pop("*", None)
     if star_comment:
-        return comments + [star_comment]
+        return [*comments, star_comment]
     return comments

--- a/isort/parse.py
+++ b/isort/parse.py
@@ -493,7 +493,7 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
                         and "isort:imports-" not in last
                         and "isort: imports-" not in last
                         and not config.treat_all_comments_as_code
-                        and not last.strip() in config.treat_comments_as_code
+                        and last.strip() not in config.treat_comments_as_code
                     ):
                         categorized_comments["above"]["from"].setdefault(import_from, []).insert(
                             0, out_lines.pop(-1)
@@ -545,7 +545,7 @@ def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedConte
                             and "isort:imports-" not in last
                             and "isort: imports-" not in last
                             and not config.treat_all_comments_as_code
-                            and not last.strip() in config.treat_comments_as_code
+                            and last.strip() not in config.treat_comments_as_code
                         ):
                             categorized_comments["above"]["straight"].setdefault(module, []).insert(
                                 0, out_lines.pop(-1)

--- a/isort/place.py
+++ b/isort/place.py
@@ -71,7 +71,7 @@ def _src_path(
         src_paths = config.src_paths
 
     root_module_name, *nested_module = name.split(".", 1)
-    new_prefix = prefix + (root_module_name,)
+    new_prefix = (*prefix, root_module_name)
     namespace = ".".join(new_prefix)
 
     for src_path in src_paths:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -437,7 +437,7 @@ class Config(_Config):
             if section in SECTION_DEFAULTS:
                 continue
 
-            if not section.lower() in known_other:
+            if section.lower() not in known_other:
                 config_keys = ", ".join(known_other.keys())
                 warn(
                     f"`sections` setting includes {section}, but no known_{section.lower()} "
@@ -852,15 +852,12 @@ def _get_config_data(file_path: str, sections: Tuple[str, ...]) -> Dict[str, Any
         for section in sections:
             if section.startswith("*.{") and section.endswith("}"):
                 extension = section[len("*.{") : -1]
-                for config_key in config.keys():
+                for config_key in config:
                     if (
                         config_key.startswith("*.{")
                         and config_key.endswith("}")
                         and extension
-                        in map(
-                            lambda text: text.strip(),
-                            config_key[len("*.{") : -1].split(","),  # noqa
-                        )
+                        in (text.strip() for text in config_key[len("*.{") : -1].split(","))
                     ):
                         settings.update(config.items(config_key))
 
@@ -877,10 +874,10 @@ def _get_config_data(file_path: str, sections: Tuple[str, ...]) -> Dict[str, Any
                 indent_size = settings.pop("tab_width", "").strip()
 
             if indent_style == "space":
-                settings["indent"] = " " * (indent_size and int(indent_size) or 4)
+                settings["indent"] = " " * ((indent_size and int(indent_size)) or 4)
 
             elif indent_style == "tab":
-                settings["indent"] = "\t" * (indent_size and int(indent_size) or 1)
+                settings["indent"] = "\t" * ((indent_size and int(indent_size)) or 1)
 
             max_line_length = settings.pop("max_line_length", "").strip()
             if max_line_length and (max_line_length == "off" or max_line_length.isdigit()):
@@ -890,7 +887,7 @@ def _get_config_data(file_path: str, sections: Tuple[str, ...]) -> Dict[str, Any
             settings = {
                 key: value
                 for key, value in settings.items()
-                if key in _DEFAULT_SETTINGS.keys() or key.startswith(KNOWN_PREFIX)
+                if key in _DEFAULT_SETTINGS or key.startswith(KNOWN_PREFIX)
             }
 
         for key, value in settings.items():

--- a/isort/sorting.py
+++ b/isort/sorting.py
@@ -51,7 +51,7 @@ def module_key(
         or str(section_name).lower() in config.length_sort_sections
     )
     _length_sort_maybe = (str(len(module_name)) + ":" + module_name) if length_sort else module_name
-    return f"{module_name in config.force_to_top and 'A' or 'B'}{prefix}{_length_sort_maybe}"
+    return f"{(module_name in config.force_to_top and 'A') or 'B'}{prefix}{_length_sort_maybe}"
 
 
 def section_key(line: str, config: Config) -> str:
@@ -90,7 +90,7 @@ def section_key(line: str, config: Config) -> str:
                 module_name = module_name.lower()
             if not config.order_by_type:
                 names = names.lower()
-            line = " import ".join([module_name, names])
+            line = f"{module_name} import {names}"
         elif not config.case_sensitive:
             line = line.lower()
     elif not config.order_by_type:

--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -333,7 +333,7 @@ def hanging_indent_with_parentheses(**interface: Any) -> str:
     while interface["imports"]:
         next_import = interface["imports"].pop(0)
         if (
-            not interface["line_separator"] in interface["statement"]
+            interface["line_separator"] not in interface["statement"]
             and "#" in interface["statement"]
         ):  # pragma: no cover # TODO: fix, this is because of test run inconsistency.
             line, comments = interface["statement"].split("#", 1)

--- a/scripts/build_profile_docs.py
+++ b/scripts/build_profile_docs.py
@@ -20,7 +20,7 @@ To use any of the listed profiles, use `isort --profile PROFILE_NAME` from the c
 
 
 def format_profile(profile_name: str, profile: Dict[str, Any]) -> str:
-    options = "\n".join(f" - **{name}**: `{repr(value)}`" for name, value in profile.items())
+    options = "\n".join(f" - **{name}**: `{value!r}`" for name, value in profile.items())
     return f"""
 #{profile_name}
 

--- a/tests/integration/test_hypothesmith.py
+++ b/tests/integration/test_hypothesmith.py
@@ -63,7 +63,7 @@ def configs(**force_strategies: st.SearchStrategy) -> st.SearchStrategy:
         "default_section": st.sampled_from(sorted(isort.settings.KNOWN_SECTION_MAPPING)),
         "force_grid_wrap": st.integers(0, 20),
         "profile": st.sampled_from(sorted(isort.settings.profiles)),
-        "py_version": st.sampled_from(("auto",) + isort.settings.VALID_PY_TARGETS),
+        "py_version": st.sampled_from(("auto", *isort.settings.VALID_PY_TARGETS)),
     }
     kwargs = {**inferred_kwargs, **specific, **force_strategies}
     return st.fixed_dictionaries({}, optional=kwargs).map(_as_config)

--- a/tests/integration/test_setting_combinations.py
+++ b/tests/integration/test_setting_combinations.py
@@ -58,7 +58,7 @@ def configs() -> st.SearchStrategy:
         "force_grid_wrap": st.integers(0, 20),
         "profile": st.sampled_from(sorted(isort.settings.profiles)),
         "sort_order": st.sampled_from(sorted(("native", "natural", "natural_plus"))),
-        "py_version": st.sampled_from(("auto",) + isort.settings.VALID_PY_TARGETS),
+        "py_version": st.sampled_from(("auto", *isort.settings.VALID_PY_TARGETS)),
     }
     kwargs = {**inferred_kwargs, **specific}
     return st.fixed_dictionaries({}, optional=kwargs).map(_as_config)

--- a/tests/unit/test_deprecated_finders.py
+++ b/tests/unit/test_deprecated_finders.py
@@ -21,7 +21,7 @@ class TestFindersManager:
 
         with patch(
             "isort.deprecated.finders.FindersManager._default_finders_classes",
-            FindersManager._default_finders_classes + (ExceptionOnInit,),  # type: ignore
+            (*FindersManager._default_finders_classes, ExceptionOnInit),
         ):
             assert FindersManager(settings.Config(verbose=True))
 

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -66,7 +66,7 @@ def test_git_hook(src_dir):
         "isort.hooks.get_lines", MagicMock(return_value=[os.path.join(src_dir, "main.py")])
     ) as run_mock:
 
-        class FakeProcessResponse(object):
+        class FakeProcessResponse:
             stdout = b"# isort: skip-file\nimport b\nimport a\n"
 
         with patch("subprocess.run", MagicMock(return_value=FakeProcessResponse())) as run_mock:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1292,11 +1292,11 @@ import b
     main.main([str(tmpdir), "--resolve-all-configs", "--cr", str(tmpdir), "--verbose"])
     out, _ = capsys.readouterr()
 
-    assert f"{setup_cfg_file!s} used for file {file1!s}" in out
-    assert f"{pyproject_toml_file!s} used for file {file2!s}" in out
-    assert f"{isort_cfg_file!s} used for file {file3!s}" in out
-    assert f"default used for file {file4!s}" in out
-    assert f"default used for file {file5!s}" in out
+    assert f"{setup_cfg_file} used for file {file1}" in out
+    assert f"{pyproject_toml_file} used for file {file2}" in out
+    assert f"{isort_cfg_file} used for file {file3}" in out
+    assert f"default used for file {file4}" in out
+    assert f"default used for file {file5}" in out
 
     assert (
         file1.read()
@@ -1353,7 +1353,7 @@ from a import x, y, z
 
     _, err = capsys.readouterr()
 
-    assert f"{file6!s} Imports are incorrectly sorted and/or formatted" in err
+    assert f"{file6} Imports are incorrectly sorted and/or formatted" in err
 
 
 def test_multiple_src_paths(tmpdir, capsys):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -177,7 +177,7 @@ def test_main(capsys, tmpdir):
     assert main.QUICK_GUIDE in out
 
     # Unless the config is requested, in which case it will be returned alone as JSON
-    main.main(base_args + ["--show-config"])
+    main.main([*base_args, "--show-config"])
     out, error = capsys.readouterr()
     returned_config = json.loads(out)
     assert returned_config
@@ -207,9 +207,12 @@ verbose=true
     )
     config_args = ["--settings-path", str(config_file)]
     main.main(
-        config_args
-        + ["--virtual-env", "/random-root-folder-that-cant-exist-right?"]
-        + ["--show-config"]
+        [
+            *config_args,
+            "--virtual-env",
+            "/random-root-folder-that-cant-exist-right?",
+            "--show-config",
+        ]
     )
     out, error = capsys.readouterr()
     assert json.loads(out)["profile"] == "hug"
@@ -223,7 +226,7 @@ import a
 """
         )
     )
-    main.main(config_args + ["-"], stdin=input_content)
+    main.main([*config_args, "-"], stdin=input_content)
     out, error = capsys.readouterr()
     assert (
         out
@@ -244,7 +247,7 @@ import a
 """
         )
     )
-    main.main(config_args + ["-", "--diff"], stdin=input_content)
+    main.main([*config_args, "-", "--diff"], stdin=input_content)
     out, error = capsys.readouterr()
     assert not error
     assert "+" in out
@@ -264,7 +267,7 @@ import a
     )
 
     with pytest.raises(SystemExit):
-        main.main(config_args + ["-", "--check-only"], stdin=input_content_check)
+        main.main([*config_args, "-", "--check-only"], stdin=input_content_check)
     out, error = capsys.readouterr()
     assert error == "ERROR:  Imports are incorrectly sorted and/or formatted.\n"
 
@@ -1289,11 +1292,11 @@ import b
     main.main([str(tmpdir), "--resolve-all-configs", "--cr", str(tmpdir), "--verbose"])
     out, _ = capsys.readouterr()
 
-    assert f"{str(setup_cfg_file)} used for file {str(file1)}" in out
-    assert f"{str(pyproject_toml_file)} used for file {str(file2)}" in out
-    assert f"{str(isort_cfg_file)} used for file {str(file3)}" in out
-    assert f"default used for file {str(file4)}" in out
-    assert f"default used for file {str(file5)}" in out
+    assert f"{setup_cfg_file!s} used for file {file1!s}" in out
+    assert f"{pyproject_toml_file!s} used for file {file2!s}" in out
+    assert f"{isort_cfg_file!s} used for file {file3!s}" in out
+    assert f"default used for file {file4!s}" in out
+    assert f"default used for file {file5!s}" in out
 
     assert (
         file1.read()
@@ -1350,7 +1353,7 @@ from a import x, y, z
 
     _, err = capsys.readouterr()
 
-    assert f"{str(file6)} Imports are incorrectly sorted and/or formatted" in err
+    assert f"{file6!s} Imports are incorrectly sorted and/or formatted" in err
 
 
 def test_multiple_src_paths(tmpdir, capsys):


### PR DESCRIPTION
Some optimizations for performance or readability.
% `ruff check --select=C4,E713,FLY,PERF401,PIE810,PLC0414,RUF005,RUF010,RUF021,SIM118,SIM201,UP004,UP033,W`
```
15	RUF005 	[*] collection-literal-concatenation
10	RUF010 	[*] explicit-f-string-type-conversion
 7	RUF021 	[*] parenthesize-chained-operators
 4	E713   	[*] not-in-test
 3	PIE810 	[*] multiple-starts-ends-with
 3	PERF401	[ ] manual-list-comprehension
 2	SIM118 	[*] in-dict-keys
 1	C413   	[*] unnecessary-call-around-sorted
 1	C417   	[*] unnecessary-map
 1	SIM201 	[*] negate-equal-op
 1	FLY002 	[*] static-join-to-f-string
 1	PLC0414	[*] useless-import-alias
 1	UP004  	[*] useless-object-inheritance
 1	UP033  	[*] lru-cache-with-maxsize-none
[*] fixable with `ruff check --fix`
```
https://docs.astral.sh/ruff/rules
---
I do not understand DeepSource's complaints that two functions have increased cyclomatic complexity when both ruff and flake8 agree that the cyclomatic complexity of these functions is unchanged.

% `ruff check --select=C901 ` # Results are the same on `main` and this branch.
```
isort/identify.py:43:5: C901 `imports` is too complex (33 > 10)
isort/settings.py:827:5: C901 `_get_config_data` is too complex (27 > 10)
```