### PR TITLE
Lint Python code with ruff

### DIFF
--- a/docs/contributing/2.-coding-standard.md
+++ b/docs/contributing/2.-coding-standard.md
@@ -52,6 +52,7 @@ All code submitted to hug should run through the following tools:
 - Flake8
    - flake8-bugbear
 - Bandit
+- ruff
 - pep8-naming
 - vulture
 - safety

--- a/isort/output.py
+++ b/isort/output.py
@@ -569,7 +569,7 @@ def _with_straight_imports(
 ) -> List[str]:
     output: List[str] = []
 
-    as_imports = any((module in parsed.as_map["straight"] for module in straight_modules))
+    as_imports = any(module in parsed.as_map["straight"] for module in straight_modules)
 
     # combine_straight_imports only works for bare imports, 'as' imports not included
     if config.combine_straight_imports and not as_imports:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -892,11 +892,11 @@ def _get_config_data(file_path: str, sections: Tuple[str, ...]) -> Dict[str, Any
 
         for key, value in settings.items():
             existing_value_type = _get_str_to_type_converter(key)
-            if existing_value_type == tuple:
+            if existing_value_type is tuple:
                 settings[key] = tuple(_as_list(value))
-            elif existing_value_type == frozenset:
+            elif existing_value_type is frozenset:
                 settings[key] = frozenset(_as_list(settings.get(key)))  # type: ignore
-            elif existing_value_type == bool:
+            elif existing_value_type is bool:
                 # Only some configuration formats support native boolean values.
                 if not isinstance(value, bool):
                     value = _as_bool(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ dev = [
     "pytest-benchmark>=3.4.1",
     "pytest-mock>=1.10",
     "requirementslib>=1.5",
+    "ruff>=0.9.6",
     "safety>=2.2.0",
     "stdlibs>=2024.10.21.16",
     "toml>=0.10.2",
@@ -168,6 +169,37 @@ module = "tests.*"
 allow_untyped_defs = true
 allow_incomplete_defs = true
 allow_untyped_calls = true
+
+[tool.ruff]
+line-length = 100
+lint.select = [
+    "ASYNC",
+    "B",
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "FLY",
+    "PIE",
+    "S",
+    "W",
+]
+lint.ignore = [
+    "B017",
+    "B028",
+    "B904",
+    "E203",
+    "E501",
+]
+lint.exclude = [ "_vendored" ]
+lint.mccabe.max-complexity = 91  # Default is 10
+
+[tool.ruff.lint.per-file-ignores]
+"isort/hooks.py" = [ "S603" ]
+"isort/settings.py" = [ "S603", "S607" ]
+"tests/*" = [ "S" ]
+"tests/unit/example_crlf_file.py" = [ "F401" ]
+"tests/unit/test_wrap_modes.py" = [ "PIE804" ]
 
 [tool.isort]
 profile = "hug"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,8 +180,13 @@ lint.select = [
     "E",
     "F",
     "FLY",
+    "PERF",
     "PIE",
+    "PLC",
+    "PLE",
+    "RUF",
     "S",
+    "UP",
     "W",
 ]
 lint.ignore = [
@@ -190,14 +195,21 @@ lint.ignore = [
     "B904",
     "E203",
     "E501",
+    "PERF203",
+    "RUF100",
+    "UP006",
+    "UP035",
 ]
-lint.exclude = [ "_vendored" ]
+lint.exclude = [ "isort/_vendored/*" ]
 lint.mccabe.max-complexity = 91  # Default is 10
 
 [tool.ruff.lint.per-file-ignores]
+"isort/deprecated/finders.py" = [ "UP034" ]
 "isort/hooks.py" = [ "S603" ]
-"isort/settings.py" = [ "S603", "S607" ]
-"tests/*" = [ "S" ]
+"isort/output.py" = [ "PLC0206" ]
+"isort/settings.py" = [ "PLC0414", "S603", "S607" ]
+"isort/setuptools_commands.py" = [ "RUF012" ]
+"tests/*" = [ "RUF001", "S" ]
 "tests/unit/example_crlf_file.py" = [ "F401" ]
 "tests/unit/test_wrap_modes.py" = [ "PIE804" ]
 

--- a/scripts/build_profile_docs.py
+++ b/scripts/build_profile_docs.py
@@ -1,6 +1,6 @@
 #! /bin/env python
 import os
-from typing import Any, Dict, Generator, Iterable, Type
+from typing import Any, Dict
 
 from isort.profiles import profiles
 

--- a/scripts/check_acknowledgments.py
+++ b/scripts/check_acknowledgments.py
@@ -46,13 +46,11 @@ async def main():
             )
             results = response.json()
             contributors.extend(
-                (
-                    contributor
-                    for contributor in results
-                    if contributor["type"] == GITHUB_USER_TYPE
-                    and contributor["login"] not in IGNORED_AUTHOR_LOGINS
-                    and f"@{contributor['login'].lower()}" not in ACKNOWLEDGEMENTS
-                )
+                contributor
+                for contributor in results
+                if contributor["type"] == GITHUB_USER_TYPE
+                and contributor["login"] not in IGNORED_AUTHOR_LOGINS
+                and f"@{contributor['login'].lower()}" not in ACKNOWLEDGEMENTS
             )
 
         unacknowledged_users = await asyncio.gather(

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,6 +7,7 @@ uv run black --target-version py39 --check .
 uv run isort --profile hug --check --diff isort/ tests/
 uv run isort --profile hug --check --diff example_*/
 uv run --with=Flake8-pyproject flake8 isort/ tests/
+uv run ruff check
  # 51457: https://github.com/tiangolo/typer/discussions/674
  # 72715: https://github.com/timothycrosley/portray/issues/95
 uv run safety check -i 72715 -i 51457 -i 59587

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -86,7 +86,7 @@ class TestLiteralParsingFailure(TestISortError):
 
     def test_variables(self):
         assert self.instance.code == "x = ["
-        assert self.instance.original_error == SyntaxError
+        assert self.instance.original_error is SyntaxError
 
 
 class TestLiteralSortTypeMismatch(TestISortError):
@@ -96,8 +96,8 @@ class TestLiteralSortTypeMismatch(TestISortError):
         )
 
     def test_variables(self):
-        assert self.instance.kind == tuple
-        assert self.instance.expected_kind == list
+        assert self.instance.kind is tuple
+        assert self.instance.expected_kind is list
 
 
 class TestAssignmentsFormatMismatch(TestISortError):

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -3019,7 +3019,7 @@ def test_import_by_paren_issue_460() -> None:
 import io
 import os
 """
-    assert isort.code((test_input)) == test_input
+    assert isort.code(test_input) == test_input
 
 
 def test_function_with_docstring() -> None:
@@ -3783,7 +3783,7 @@ def test_command_line(tmpdir, capfd, multiprocess: bool) -> None:
 
     tmpdir.join("file1.py").write("import re\nimport os\n\nimport contextlib\n\n\nimport isort")
     tmpdir.join("file2.py").write(
-        ("import collections\nimport time\n\nimport abc" "\n\n\nimport isort")
+        "import collections\nimport time\n\nimport abc" "\n\n\nimport isort"
     )
     arguments = [str(tmpdir), "--settings-path", os.getcwd()]
     if multiprocess:

--- a/uv.lock
+++ b/uv.lock
@@ -977,6 +977,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-mock" },
     { name = "requirementslib" },
+    { name = "ruff" },
     { name = "safety" },
     { name = "stdlibs" },
     { name = "toml" },
@@ -1022,6 +1023,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=3.4.1" },
     { name = "pytest-mock", specifier = ">=1.10" },
     { name = "requirementslib", specifier = ">=1.5" },
+    { name = "ruff", specifier = ">=0.9.6" },
     { name = "safety", specifier = ">=2.2.0" },
     { name = "stdlibs", specifier = ">=2024.10.21.16" },
     { name = "toml", specifier = ">=0.10.2" },
@@ -2533,6 +2535,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/b3/fe4d84446f7e4887e3bea7ceff0a7df23790b5ed625f830e79ace88ebefb/ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2c59aa6170b990d8d2719323e628aaf36f3bfbc1c26279c0eeeb24d05d2d11c7", size = 666365 },
     { url = "https://files.pythonhosted.org/packages/6e/b3/7feb99a00bfaa5c6868617bb7651308afde85e5a0b23cd187fe5de65feeb/ruamel.yaml.clib-0.2.12-cp39-cp39-win32.whl", hash = "sha256:beffaed67936fbbeffd10966a4eb53c402fafd3d6833770516bf7314bc6ffa12", size = 100863 },
     { url = "https://files.pythonhosted.org/packages/93/07/de635108684b7a5bb06e432b0930c5a04b6c59efe73bd966d8db3cc208f2/ruamel.yaml.clib-0.2.12-cp39-cp39-win_amd64.whl", hash = "sha256:040ae85536960525ea62868b642bdb0c2cc6021c9f9d507810c0c604e66f5a7b", size = 118653 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/e1/e265aba384343dd8ddd3083f5e33536cd17e1566c41453a5517b5dd443be/ruff-0.9.6.tar.gz", hash = "sha256:81761592f72b620ec8fa1068a6fd00e98a5ebee342a3642efd84454f3031dca9", size = 3639454 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/e3/3d2c022e687e18cf5d93d6bfa2722d46afc64eaa438c7fbbdd603b3597be/ruff-0.9.6-py3-none-linux_armv6l.whl", hash = "sha256:2f218f356dd2d995839f1941322ff021c72a492c470f0b26a34f844c29cdf5ba", size = 11714128 },
+    { url = "https://files.pythonhosted.org/packages/e1/22/aff073b70f95c052e5c58153cba735748c9e70107a77d03420d7850710a0/ruff-0.9.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b908ff4df65dad7b251c9968a2e4560836d8f5487c2f0cc238321ed951ea0504", size = 11682539 },
+    { url = "https://files.pythonhosted.org/packages/75/a7/f5b7390afd98a7918582a3d256cd3e78ba0a26165a467c1820084587cbf9/ruff-0.9.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b109c0ad2ececf42e75fa99dc4043ff72a357436bb171900714a9ea581ddef83", size = 11132512 },
+    { url = "https://files.pythonhosted.org/packages/a6/e3/45de13ef65047fea2e33f7e573d848206e15c715e5cd56095589a7733d04/ruff-0.9.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1de4367cca3dac99bcbd15c161404e849bb0bfd543664db39232648dc00112dc", size = 11929275 },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/23d04cd6c43b2e641ab961ade8d0b5edb212ecebd112506188c91f2a6e6c/ruff-0.9.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac3ee4d7c2c92ddfdaedf0bf31b2b176fa7aa8950efc454628d477394d35638b", size = 11466502 },
+    { url = "https://files.pythonhosted.org/packages/b5/6f/3a8cf166f2d7f1627dd2201e6cbc4cb81f8b7d58099348f0c1ff7b733792/ruff-0.9.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5dc1edd1775270e6aa2386119aea692039781429f0be1e0949ea5884e011aa8e", size = 12676364 },
+    { url = "https://files.pythonhosted.org/packages/f5/c4/db52e2189983c70114ff2b7e3997e48c8318af44fe83e1ce9517570a50c6/ruff-0.9.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4a091729086dffa4bd070aa5dab7e39cc6b9d62eb2bef8f3d91172d30d599666", size = 13335518 },
+    { url = "https://files.pythonhosted.org/packages/66/44/545f8a4d136830f08f4d24324e7db957c5374bf3a3f7a6c0bc7be4623a37/ruff-0.9.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d1bbc6808bf7b15796cef0815e1dfb796fbd383e7dbd4334709642649625e7c5", size = 12823287 },
+    { url = "https://files.pythonhosted.org/packages/c5/26/8208ef9ee7431032c143649a9967c3ae1aae4257d95e6f8519f07309aa66/ruff-0.9.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:589d1d9f25b5754ff230dce914a174a7c951a85a4e9270613a2b74231fdac2f5", size = 14592374 },
+    { url = "https://files.pythonhosted.org/packages/31/70/e917781e55ff39c5b5208bda384fd397ffd76605e68544d71a7e40944945/ruff-0.9.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc61dd5131742e21103fbbdcad683a8813be0e3c204472d520d9a5021ca8b217", size = 12500173 },
+    { url = "https://files.pythonhosted.org/packages/84/f5/e4ddee07660f5a9622a9c2b639afd8f3104988dc4f6ba0b73ffacffa9a8c/ruff-0.9.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5e2d9126161d0357e5c8f30b0bd6168d2c3872372f14481136d13de9937f79b6", size = 11906555 },
+    { url = "https://files.pythonhosted.org/packages/f1/2b/6ff2fe383667075eef8656b9892e73dd9b119b5e3add51298628b87f6429/ruff-0.9.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:68660eab1a8e65babb5229a1f97b46e3120923757a68b5413d8561f8a85d4897", size = 11538958 },
+    { url = "https://files.pythonhosted.org/packages/3c/db/98e59e90de45d1eb46649151c10a062d5707b5b7f76f64eb1e29edf6ebb1/ruff-0.9.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4cae6c4cc7b9b4017c71114115db0445b00a16de3bcde0946273e8392856f08", size = 12117247 },
+    { url = "https://files.pythonhosted.org/packages/ec/bc/54e38f6d219013a9204a5a2015c09e7a8c36cedcd50a4b01ac69a550b9d9/ruff-0.9.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:19f505b643228b417c1111a2a536424ddde0db4ef9023b9e04a46ed8a1cb4656", size = 12554647 },
+    { url = "https://files.pythonhosted.org/packages/a5/7d/7b461ab0e2404293c0627125bb70ac642c2e8d55bf590f6fce85f508f1b2/ruff-0.9.6-py3-none-win32.whl", hash = "sha256:194d8402bceef1b31164909540a597e0d913c0e4952015a5b40e28c146121b5d", size = 9949214 },
+    { url = "https://files.pythonhosted.org/packages/ee/30/c3cee10f915ed75a5c29c1e57311282d1a15855551a64795c1b2bbe5cf37/ruff-0.9.6-py3-none-win_amd64.whl", hash = "sha256:03482d5c09d90d4ee3f40d97578423698ad895c87314c4de39ed2af945633caa", size = 10999914 },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/d71f44b93e3aa86ae232af1f2126ca7b95c0f515ec135462b3e1f351441c/ruff-0.9.6-py3-none-win_arm64.whl", hash = "sha256:0e2bb706a2be7ddfea4a4af918562fdc1bcb16df255e5fa595bbd800ce322a5a", size = 10177499 },
 ]
 
 [[package]]


### PR DESCRIPTION
As suggested at https://github.com/PyCQA/isort/pull/2353#pullrequestreview-2583241874 let's add the [`ruff` linter](https://docs.astral.sh/ruff).