### PR TITLE
GitHub Actions: Use uv cache, not pip cache

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,11 +22,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
+          enable-cache: true
           version: ">=0.5.24"
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,11 +22,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
+          enable-cache: true
           version: ">=0.5.24"
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
+          enable-cache: true
           version: ">=0.5.24"
 
       - name: Install dependencies


### PR DESCRIPTION
Fix the failing GitHub Actions tests by using uv cache, instead of pip cache.
* https://docs.astral.sh/uv/guides/integration/github/#caching

A subset of:
* #2364 which also upgrades to uv v0.6.0 which contains breaking changes.