### PR TITLE
Upgrade to uv>=0.6.0 and enable-cache

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
-          version: ">=0.5.24"
+          enable-cache: true
+          version: ">=0.6.0"
 
       - name: Install dependencies
         run: uv sync --all-extras --frozen

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
-          version: ">=0.5.24"
+          enable-cache: true
+          version: ">=0.6.0"
 
       - name: Install dependencies
         run: uv sync --all-extras --frozen

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
-          version: ">=0.5.24"
+          version: ">=0.6.0"
 
       - name: Build package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
-          version: ">=0.5.24"
+          version: ">=0.6.0"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
       - name: Install UV
         uses: astral-sh/setup-uv@v5
         with:
-          version: ">=0.5.24"
+          enable-cache: true
+          version: ">=0.6.0"
 
       - name: Install dependencies
         run: uv sync --all-extras --frozen

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /isort
 COPY pyproject.toml uv.lock /isort/
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:0.5.24 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.6.0 /uv /uvx /bin/
 
 # Setup as minimal a stub project as possible, simply to allow caching base dependencies
 # between builds.


### PR DESCRIPTION
A superset of
* #2363

This uses uv cache, not pip cache but also upgrades uv to v0.6.0 which contains several breaking changes...
* https://github.com/astral-sh/uv/releases --> uv version: >= 0.6.0