### PR TITLE
Use `safety scan` instead of the deprecated `safety check`

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,5 +9,5 @@ uv run isort --profile hug --check --diff example_*/
 uv run --with=Flake8-pyproject flake8 isort/ tests/
  # 51457: https://github.com/tiangolo/typer/discussions/674
  # 72715: https://github.com/timothycrosley/portray/issues/95
-uv run safety check -i 72715 -i 51457 -i 59587
+uv run safety scan -i 72715 -i 51457 -i 59587
 uv run bandit -r isort/ -x isort/_vendored


### PR DESCRIPTION
Should we drop `safety` or get a free API key?
* https://docs.safetycli.com/safety-docs/safety-cli/scanning-in-ci-cd

The lint GitHub Action currently generates:
> DEPRECATED: this command (`check`) has been DEPRECATED, and will be unsupported beyond 01 June 2024.
>
> We highly encourage switching to the new `scan` command which is easier to use, more powerful, and can be set up to mimic the deprecated command if required.
```diff
- uv run safety check -i 72715 -i 51457 -i 59587
+ uv run safety scan -i 72715 -i 51457 -i 59587
```
https://docs.safetycli.com/safety-docs/safety-cli/migrating-from-safety-cli-2.x-to-safety-cli-3.x#switching-to-the-new-scan-command

> Please login or register Safety CLI (free forever) to scan and secure your 
projects with Safety
(R)egister for a free account in 30 seconds, or (L)ogin with an existing account
Unhandled exception happened: EOF when reading a line
to continue (R/L): 