### PR TITLE
Resolve bandit warnings

### DIFF
--- a/isort/hooks.py
+++ b/isort/hooks.py
@@ -5,7 +5,7 @@ usage:
 """
 
 import os
-import subprocess  # nosec - Needed for hook
+import subprocess  # nosec # Needed for hook
 from pathlib import Path
 from typing import List, Optional
 
@@ -18,7 +18,7 @@ def get_output(command: List[str]) -> str:
     :param str command: the command to run
     :returns: the stdout output of the command
     """
-    result = subprocess.run(command, stdout=subprocess.PIPE, check=True)  # nosec - trusted input
+    result = subprocess.run(command, stdout=subprocess.PIPE, check=True)  # nosec # trusted input
     return result.stdout.decode()
 
 

--- a/isort/hooks.py
+++ b/isort/hooks.py
@@ -5,7 +5,7 @@ usage:
 """
 
 import os
-import subprocess  # nosec # Needed for hook
+import subprocess  # nosec
 from pathlib import Path
 from typing import List, Optional
 
@@ -18,7 +18,7 @@ def get_output(command: List[str]) -> str:
     :param str command: the command to run
     :returns: the stdout output of the command
     """
-    result = subprocess.run(command, stdout=subprocess.PIPE, check=True)  # nosec # trusted input
+    result = subprocess.run(command, stdout=subprocess.PIPE, check=True)  # nosec
     return result.stdout.decode()
 
 

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -9,7 +9,7 @@ import os
 import posixpath
 import re
 import stat
-import subprocess  # nosec: Needed for gitignore support.
+import subprocess  # nosec # Needed for gitignore support.
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path


### PR DESCRIPTION
The `nosec` flags benefit from human-readable explanation, but bandit was seeing the trailing text and throwing warnings:

```
WARNING Test in comment: Needed is not a test name or id, ignoring
WARNING Test in comment: for is not a test name or id, ignoring
WARNING Test in comment: gitignore is not a test name or id, ignoring
WARNING Test in comment: support is not a test name or id, ignoring
```

This is addressed by using another `#` character to hide the text.