### PR TITLE
fix typo in _get_files_from_dir_cached test

### DIFF
--- a/isort/deprecated/finders.py
+++ b/isort/deprecated/finders.py
@@ -309,7 +309,7 @@ class RequirementsFinder(ReqsBaseFinder):
                 for subfile_name in os.listdir(full_path):
                     results.extend(
                         os.path.join(full_path, subfile_name)
-                        for ext in cls.exts  # type: ignore[attr-defined]
+                        for ext in cls.exts
                         if subfile_name.endswith(ext)
                     )
                 continue

--- a/isort/deprecated/finders.py
+++ b/isort/deprecated/finders.py
@@ -309,7 +309,7 @@ class RequirementsFinder(ReqsBaseFinder):
                 for subfile_name in os.listdir(full_path):
                     results.extend(
                         os.path.join(full_path, subfile_name)
-                        for ext in cls.ext  # type: ignore[attr-defined]
+                        for ext in cls.exts  # type: ignore[attr-defined]
                         if subfile_name.endswith(ext)
                     )
                 continue


### PR DESCRIPTION
Fixes _get_files_from_dir_cached test which was failing because of an attribute error due to a typo