### PR TITLE
Use working isort version in pre-commit example

### DIFF
--- a/docs/configuration/black_compatibility.md
+++ b/docs/configuration/black_compatibility.md
@@ -56,7 +56,7 @@ You can also set the profile directly when integrating isort within pre-commit.
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
pre-commit fails to initialize an environment for rev 5.6.4 with some weird error about Poetry.

```
$ pre-commit run --all-files
...
          RuntimeError: The Poetry configuration is invalid:
            - tool.poetry.extras.pipfile_deprecated_finder[2] must match pattern ^[a-zA-Z-_.0-9]+$
```