### PR TITLE
docs: update pre-commit examples to version 6.1.0

### DIFF
--- a/docs/configuration/pre-commit.md
+++ b/docs/configuration/pre-commit.md
@@ -9,7 +9,7 @@ To use isort's official pre-commit integration add the following config:
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.1.0
     hooks:
       - id: isort
         name: isort (python)
@@ -20,7 +20,7 @@ over different file types (ex: python vs cython vs pyi) you can do so with the f
 
 ```yaml
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.1.0
     hooks:
       - id: isort
         name: isort (python)

--- a/docs/upgrade_guides/5.0.0.md
+++ b/docs/upgrade_guides/5.0.0.md
@@ -82,7 +82,7 @@ isort now includes an optimized precommit configuration in the repo itself. To u
 
 ```
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.1.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
Update outdated version references from 5.13.2 to 6.1.0 in:
- docs/configuration/pre-commit.md (2 occurrences)
- docs/upgrade_guides/5.0.0.md (1 occurrence)

The documentation was showing version 5.13.2 (from December 2023) while the latest release is 6.1.0 (October 2025).

Related issues will be created for:
- Missing CHANGELOG entries for 6.0.0, 6.0.1, 6.1.0
- Missing upgrade guide for 6.0.0