### PR TITLE
Show absolute paths in skipped file messages

### DIFF
--- a/isort/files.py
+++ b/isort/files.py
@@ -21,7 +21,7 @@ def find(
                     full_path = base_path / dirname
                     resolved_path = full_path.resolve()
                     if config.is_skipped(full_path):
-                        skipped.append(dirname)
+                        skipped.append(str(full_path))
                         dirnames.remove(dirname)
                     else:
                         if resolved_path in visited_dirs:  # pragma: no cover
@@ -32,7 +32,7 @@ def find(
                     filepath = os.path.join(dirpath, filename)
                     if config.is_supported_filetype(filepath):
                         if config.is_skipped(Path(os.path.abspath(filepath))):
-                            skipped.append(filename)
+                            skipped.append(os.path.abspath(filepath))
                         else:
                             yield filepath
         elif not os.path.exists(path):

--- a/isort/main.py
+++ b/isort/main.py
@@ -1175,7 +1175,7 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
             filtered_files = []
             for file_name in file_names:
                 if config.is_skipped(Path(file_name)):
-                    skipped.append(file_name)
+                    skipped.append(str(Path(file_name).resolve()))
                 else:
                     filtered_files.append(file_name)
             file_names = filtered_files


### PR DESCRIPTION
When files are skipped, isort now displays their absolute paths in verbose mode, consistent with the "Fixing" messages. This improves debugging by making it clear which files are being skipped.

Changes:
- isort/main.py:1178 - Convert file_name to absolute path before appending
- isort/files.py:24 - Use full_path instead of just dirname
- isort/files.py:35 - Use absolute filepath instead of just filename

Fixes #2412