### PR TITLE
Try and fix `dependabot` for `uv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ Changelog = "https://github.com/PyCQA/isort/releases"
 source = "vcs"
 
 [tool.hatch.version.raw-options]
+# Fallback needed because of https://github.com/dependabot/dependabot-core/issues/12340
+fallback_version = "0.0.0"
 local_scheme = "no-local-version"
 
 [project.scripts]


### PR DESCRIPTION
Hopefully fixes the `dependabot` job, see failure in https://github.com/PyCQA/isort/actions/runs/18293677601/job/52086852805

Fix from https://github.com/dependabot/dependabot-core/issues/12340