### PR TITLE
Feature/fix issue 1959 - Publish an official isort Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,7 @@
-# project build medadata that can't be used in docker
-Dockerfile
-.appveyor.yml
-.dockerignore
-.pre-commit-hooks.yaml
-.travis.yml
-.git*
+# Ignore everything ...
+*
 
-# documentation not needed
-CHANGELOG.md
-LICENSE
-MANIFEST.in
-.undertake
-example.gif
-logo.png
-art/
-docs/
+# ... except:
+!isort
+!pyproject.toml
+!README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     if: github.repository_owner == 'PyCQA'
     name: Release
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
@@ -55,3 +58,34 @@ jobs:
           tag: ${{ steps.check-version.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build a new Docker image and push it to the GitHub Container Registry
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,20 @@
-FROM python:3.13
+# Build stage
+FROM python:3.13-alpine AS builder
 
 WORKDIR /isort
-COPY pyproject.toml uv.lock /isort/
+COPY . .
 
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:0.6.0 /uv /uvx /bin/
+RUN pip install --no-cache-dir uv
 
-# Setup as minimal a stub project as possible, simply to allow caching base dependencies
-# between builds.
-#
-# If error is encountered in these steps, can safely be removed locally.
-RUN mkdir -p /isort/isort
-RUN mkdir -p /isort/tests
-RUN touch /isort/isort/__init__.py
-RUN touch /isort/tests/__init__.py
-RUN touch /isort/README.md
-COPY . /isort
-RUN SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv sync --all-extras --frozen
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv build .
 
-# Install latest code for actual project
-RUN rm -rf /isort
+# Release stage
+FROM python:3.13-alpine
 
-# Run full test suite
-CMD /isort/scripts/test.sh
+# Install the wheel from the build stage
+COPY --from=builder /isort/dist/ /tmp/
+RUN \
+    pip install --no-cache-dir /tmp/*.whl && \
+    rm /tmp/*.whl
+
+ENTRYPOINT ["isort"]


### PR DESCRIPTION
This adds steps to the existing release workflow which package the isort Python distribution as a Docker image and push it to the GitHub container registry.

This fixes issue #1959.