### PR TITLE
Fix line separator detection not considering form feed as white space

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -159,7 +159,9 @@ def process(
         else:
             stripped_line = line.strip()
             if stripped_line and not line_separator:
-                line_separator = line[len(line.rstrip()) :].replace(" ", "").replace("\t", "")
+                line_separator = (
+                    line[len(line.rstrip()) :].replace(" ", "").replace("\t", "").replace("\f", "")
+                )
 
             for file_skip_comment in FILE_SKIP_COMMENTS:
                 if file_skip_comment in line:

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -3443,6 +3443,17 @@ def test_ensure_line_endings_are_preserved_issue_493() -> None:
     assert isort.code(test_input) == test_input
 
 
+@pytest.mark.parametrize("ws", [" ", "\t", "\f"])
+def test_line_endings_are_detected_ignoring_whitespace(ws: str) -> None:
+    """Test to ensure line endings are not converted"""
+    test_input = f"# foo{ws}\r\nimport a\r\n\r\ncimport z\r\n"
+    assert isort.code(test_input) == test_input
+    test_input = f"# foo{ws}\rimport a\r\rcimport z\r"
+    assert isort.code(test_input) == test_input
+    test_input = f"# foo{ws}\nimport a\n\ncimport z\n"
+    assert isort.code(test_input) == test_input
+
+
 def test_not_splitted_sections() -> None:
     whiteline = "\n"
     stdlib_section = "import unittest\n"


### PR DESCRIPTION
While working on https://github.com/PyCQA/isort/pull/1966, I this bit of code that didn't seem quite right given that Python considers ` `, `\t`, and `\f` all as white space (see https://docs.python.org/3/reference/lexical_analysis.html).

Finding an example for a failing test took me a fair bit of time as the auto-detected line separator isn't used a whole lot.