### PR TITLE
Fix whitespace insensitive check triggering on tabs

### DIFF
--- a/isort/format.py
+++ b/isort/format.py
@@ -86,7 +86,9 @@ def ask_whether_to_apply_changes_to_file(file_path: str) -> bool:
 
 
 def remove_whitespace(content: str, line_separator: str = "\n") -> str:
-    content = content.replace(line_separator, "").replace(" ", "").replace("\x0c", "")
+    content = (
+        content.replace(line_separator, "").replace(" ", "").replace("\t", "").replace("\f", "")
+    )
     return content
 
 

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -4211,9 +4211,13 @@ def test_to_ensure_empty_line_not_added_to_file_start_issue_889() -> None:
     assert isort.code(test_input) == test_input
 
 
-def test_to_ensure_correctly_handling_of_whitespace_only_issue_811(capsys) -> None:
-    test_input = 'import os\nimport sys\n\n\x0c\ndef my_function():\n    print("hi")\n'
-    isort.code(test_input, ignore_whitespace=True)
+@pytest.mark.parametrize("ws", ["", " ", "\t", "\f", "\n"])
+def test_to_ensure_correctly_handling_of_whitespace_only_issue_811(
+    ws: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    test_input = f'import os\nimport sys\n\n{ws}\ndef my_function():\n    print("hi")\n'
+    assert isort.check_code(test_input, ignore_whitespace=True)
     out, err = capsys.readouterr()
     assert out == ""
     assert err == ""


### PR DESCRIPTION
This amends https://github.com/PyCQA/isort/pull/898/ as tabs (`\t`) are also considered whitespace in Python.

Found while working on https://github.com/PyCQA/isort/pull/1966