### PR TITLE
Ensure `multiprocessing.Pool` is always closed and joined

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1059,6 +1059,9 @@ def identify_imports_main(
             print(str(identified_import))
 
 
+# Ignore DeepSource cyclomatic complexity check for this function. It is one
+# the main entrypoints so sort of expected to be complex.
+# skipcq: PY-R1000
 def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) -> None:
     arguments = parse_args(argv)
     if arguments.get("show_version"):


### PR DESCRIPTION
References https://github.com/PyCQA/isort/issues/2438

Fixes a `ResourceWarning` as indicated in that issue. I misread the isuse and thought it was about the `ResourceWarning`. It would be good to fix this anyway as I'll dive a bit more into the actual issue 😄 