### PR TITLE
Turn some warnings into errors in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,4 +224,7 @@ filterwarnings = [
   "ignore:.*from_type\\(thing=Path\\).*:hypothesis.errors.SmallSearchSpaceWarning",
   # Used by pip-api. To be removed when we remove that deprecated finder.
   "ignore:.*sre_constants.*:DeprecationWarning",
+  # Many escape sequence warnings in transitive dependencies from pipreqs. To be removed when we
+  # remove that deprecated finder.
+  "ignore:.*invalid escape sequence.*:SyntaxWarning",
 ]


### PR DESCRIPTION
References https://github.com/PyCQA/isort/issues/2438

Inspired by that issue it would be good to at least get early notifications of `DeprecationWarnings`, `ResourceWarnings` and others.

Needs a little bit of work though.