### PR TITLE
Turn some warnings into errors in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,3 +210,13 @@ src_paths = ["isort", "tests"]
 skip = [
     "tests/unit/example_crlf_file.py"
 ]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  "error",
+  # isort raies many UserWarnings itself, ignore these globally as it is too much work to disable
+  # these per warning for now.
+  "ignore::UserWarning",
+  # We don't really care about randomizing paths and don't want to add another hypothesis dependency
+  "ignore:.*from_type\\(thing=Path\\).*:hypothesis.errors.SmallSearchSpaceWarning",
+]


### PR DESCRIPTION
Unblocked by https://github.com/PyCQA/isort/pull/2446/

This should hopefully help catch `DeprecationWarnings` sooner.