### PR TITLE
Fix unindented comments being corrupted in indented blocks

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -420,7 +420,8 @@ def process(
 
                     if indent:
                         import_section = "".join(
-                            line[len(indent) :] for line in import_section.splitlines(keepends=True)
+                            line[len(indent) :] if line.startswith(indent) else line
+                            for line in import_section.splitlines(keepends=True)
                         )
 
                     parsed_content = parse.file_contents(import_section, config=config)

--- a/tests/unit/test_ticketed_features.py
+++ b/tests/unit/test_ticketed_features.py
@@ -1073,3 +1073,17 @@ def use_libc_math():
 """,
         show_diff=True,
     )
+
+
+def test_unindented_comment_in_indented_block_issue_1899():
+    """Test that unindented comments before indented imports are not corrupted.
+
+    See: https://github.com/PyCQA/isort/issues/1899
+    """
+    test_input = """import sys
+
+if True:
+# this will get cut off
+    import os
+"""
+    assert isort.code(test_input) == test_input


### PR DESCRIPTION
## Summary

When an unindented comment appears before an indented import block, isort corrupts the comment by stripping `len(indent)` characters from the start of every line—even lines that don't begin with that indent.

**Before fix:**
```python
# Input
if True:
# this will get cut off
    import os

# Output (corrupted)
if True:
is will get cut off
    import os
```

**After fix:** The comment is preserved correctly.

## Root cause

In `isort/core.py` line 422, the indent-stripping logic:
```python
line[len(indent):] for line in import_section.splitlines(keepends=True)
```
blindly slices every line without checking if it actually starts with the indent prefix.

## Fix

Added a `line.startswith(indent)` guard so only properly indented lines get stripped:
```python
line[len(indent):] if line.startswith(indent) else line
```

## Test plan

- Added `test_unindented_comment_in_indented_block_issue_1899` to `tests/unit/test_ticketed_features.py`
- Verified existing unit tests still pass (283 passed, 1 pre-existing failure unrelated to this change)

Fixes #1899

🤖 Generated with [Claude Code](https://claude.com/claude-code)