### PR TITLE
Fix #2461: Added compression to stdlibs for Python 3.14 in isort/stdlibs/py314.py

### DIFF
--- a/isort/stdlibs/py314.py
+++ b/isort/stdlibs/py314.py
@@ -31,6 +31,7 @@ stdlib = {
     "collections",
     "colorsys",
     "compileall",
+    "compression",
     "concurrent",
     "configparser",
     "contextlib",


### PR DESCRIPTION
Fix for issue #2461