### PR TITLE
Simplify sort file

### DIFF
--- a/isort/api.py
+++ b/isort/api.py
@@ -436,33 +436,24 @@ def sort_file(
     with io.File.read(filename) as source_file:
         actual_file_path = file_path or source_file.path
         config = _config(path=actual_file_path, config=file_config, **config_kwargs)
-        changed: bool = False
-        try:
-            if write_to_stdout:
-                return sort_stream(
-                    input_stream=source_file.stream,
-                    output_stream=sys.stdout,
-                    config=config,
-                    file_path=actual_file_path,
-                    disregard_skip=disregard_skip,
-                    extension=extension,
-                )
 
-            # Prepare the output stream. Using the `is_changed_event` we propagate whether the file
-            # should flush the output to the source file.
-            is_changed_event = Event()
-            if output:
-                output_stream_context: AbstractContextManager[TextIO] = nullcontext(output)
-            elif config.overwrite_in_place:
-                output_stream_context = _in_memory_output_stream_context(
-                    source_file, is_changed_event
-                )
-            else:
-                output_stream_context = _file_output_stream_context(
-                    filename, source_file, is_changed_event
-                )
+        if write_to_stdout:
+            output = sys.stdout
 
-            with output_stream_context as output_stream:
+        # Prepare the output stream. Using the `is_changed_event` we propagate whether the file
+        # should flush the output to the source file.
+        is_changed_event = Event()
+        if output:
+            output_stream_context: AbstractContextManager[TextIO] = nullcontext(output)
+        elif config.overwrite_in_place:
+            output_stream_context = _in_memory_output_stream_context(source_file, is_changed_event)
+        else:
+            output_stream_context = _file_output_stream_context(
+                filename, source_file, is_changed_event
+            )
+
+        with output_stream_context as output_stream:
+            try:
                 changed = sort_stream(
                     input_stream=source_file.stream,
                     output_stream=output_stream,
@@ -471,37 +462,43 @@ def sort_file(
                     disregard_skip=disregard_skip,
                     extension=extension,
                 )
-                if changed:
-                    if show_diff or ask_to_apply:
-                        output_stream.seek(0)
-                        source_file.stream.seek(0)
-                        show_unified_diff(
-                            file_input=source_file.stream.read(),
-                            file_output=output_stream.read(),
-                            file_path=actual_file_path,
-                            output=(None if show_diff is True else cast(TextIO, show_diff)),
-                            color_output=config.color_output,
-                        )
-                        if show_diff or (
-                            ask_to_apply
-                            and not ask_whether_to_apply_changes_to_file(str(source_file.path))
-                        ):
-                            return False
+            except ExistingSyntaxErrors:
+                warn(
+                    f"{actual_file_path} unable to sort due to existing syntax errors",
+                    stacklevel=2,
+                )
+                return False
+            except IntroducedSyntaxErrors:  # pragma: no cover
+                warn(
+                    f"{actual_file_path} unable to sort as isort introduces new syntax errors",
+                    stacklevel=2,
+                )
+                return False
 
-                    is_changed_event.set()
+            if not changed or write_to_stdout:
+                return changed
 
-                    if not config.quiet:
-                        print(f"Fixing {source_file.path}")
+            if show_diff or ask_to_apply:
+                output_stream.seek(0)
+                source_file.stream.seek(0)
+                show_unified_diff(
+                    file_input=source_file.stream.read(),
+                    file_output=output_stream.read(),
+                    file_path=actual_file_path,
+                    output=(None if show_diff is True else cast(TextIO, show_diff)),
+                    color_output=config.color_output,
+                )
+                if show_diff or (
+                    ask_to_apply and not ask_whether_to_apply_changes_to_file(str(source_file.path))
+                ):
+                    return False
 
-        except ExistingSyntaxErrors:
-            warn(f"{actual_file_path} unable to sort due to existing syntax errors", stacklevel=2)
-        except IntroducedSyntaxErrors:  # pragma: no cover
-            warn(
-                f"{actual_file_path} unable to sort as isort introduces new syntax errors",
-                stacklevel=2,
-            )
+            if not config.quiet:
+                print(f"Fixing {source_file.path}")
 
-        return changed
+            is_changed_event.set()
+
+            return True
 
 
 def find_imports_in_code(

--- a/isort/api.py
+++ b/isort/api.py
@@ -414,7 +414,7 @@ def sort_file(
         changed: bool = False
         try:
             if write_to_stdout:
-                changed = sort_stream(
+                return sort_stream(
                     input_stream=source_file.stream,
                     output_stream=sys.stdout,
                     config=config,
@@ -422,79 +422,79 @@ def sort_file(
                     disregard_skip=disregard_skip,
                     extension=extension,
                 )
-            else:
-                if output is None:
-                    try:
-                        if config.overwrite_in_place:
-                            output_stream_context = _in_memory_output_stream_context()
-                        else:
-                            output_stream_context = _file_output_stream_context(
-                                filename, source_file
-                            )
-                        with output_stream_context as output_stream:
-                            changed = sort_stream(
-                                input_stream=source_file.stream,
-                                output_stream=output_stream,
-                                config=config,
-                                file_path=actual_file_path,
-                                disregard_skip=disregard_skip,
-                                extension=extension,
-                            )
-                            output_stream.seek(0)
-                            if changed:
-                                if show_diff or ask_to_apply:
-                                    source_file.stream.seek(0)
-                                    show_unified_diff(
-                                        file_input=source_file.stream.read(),
-                                        file_output=output_stream.read(),
-                                        file_path=actual_file_path,
-                                        output=(
-                                            None if show_diff is True else cast(TextIO, show_diff)
-                                        ),
-                                        color_output=config.color_output,
-                                    )
-                                    if show_diff or (
-                                        ask_to_apply
-                                        and not ask_whether_to_apply_changes_to_file(
-                                            str(source_file.path)
-                                        )
-                                    ):
-                                        return False
-                                source_file.stream.close()
-                                if config.overwrite_in_place:
-                                    output_stream.seek(0)
-                                    with source_file.path.open("w") as fs:
-                                        shutil.copyfileobj(output_stream, fs)
-                        if changed:
-                            if not config.overwrite_in_place:
-                                tmp_file = _tmp_file(source_file)
-                                tmp_file.replace(source_file.path)
-                            if not config.quiet:
-                                print(f"Fixing {source_file.path}")
-                    finally:
-                        if not config.overwrite_in_place:  # pragma: no branch
-                            tmp_file = _tmp_file(source_file)
-                            tmp_file.unlink(missing_ok=True)
-                else:
-                    changed = sort_stream(
-                        input_stream=source_file.stream,
-                        output_stream=output,
-                        config=config,
-                        file_path=actual_file_path,
-                        disregard_skip=disregard_skip,
-                        extension=extension,
-                    )
-                    if changed and show_diff:
-                        source_file.stream.seek(0)
-                        output.seek(0)
-                        show_unified_diff(
-                            file_input=source_file.stream.read(),
-                            file_output=output.read(),
-                            file_path=actual_file_path,
-                            output=None if show_diff is True else show_diff,
-                            color_output=config.color_output,
+                
+            if output is None:
+                try:
+                    if config.overwrite_in_place:
+                        output_stream_context = _in_memory_output_stream_context()
+                    else:
+                        output_stream_context = _file_output_stream_context(
+                            filename, source_file
                         )
-                    source_file.stream.close()
+                    with output_stream_context as output_stream:
+                        changed = sort_stream(
+                            input_stream=source_file.stream,
+                            output_stream=output_stream,
+                            config=config,
+                            file_path=actual_file_path,
+                            disregard_skip=disregard_skip,
+                            extension=extension,
+                        )
+                        output_stream.seek(0)
+                        if changed:
+                            if show_diff or ask_to_apply:
+                                source_file.stream.seek(0)
+                                show_unified_diff(
+                                    file_input=source_file.stream.read(),
+                                    file_output=output_stream.read(),
+                                    file_path=actual_file_path,
+                                    output=(
+                                        None if show_diff is True else cast(TextIO, show_diff)
+                                    ),
+                                    color_output=config.color_output,
+                                )
+                                if show_diff or (
+                                    ask_to_apply
+                                    and not ask_whether_to_apply_changes_to_file(
+                                        str(source_file.path)
+                                    )
+                                ):
+                                    return False
+                            source_file.stream.close()
+                            if config.overwrite_in_place:
+                                output_stream.seek(0)
+                                with source_file.path.open("w") as fs:
+                                    shutil.copyfileobj(output_stream, fs)
+                    if changed:
+                        if not config.overwrite_in_place:
+                            tmp_file = _tmp_file(source_file)
+                            tmp_file.replace(source_file.path)
+                        if not config.quiet:
+                            print(f"Fixing {source_file.path}")
+                finally:
+                    if not config.overwrite_in_place:  # pragma: no branch
+                        tmp_file = _tmp_file(source_file)
+                        tmp_file.unlink(missing_ok=True)
+            else:
+                changed = sort_stream(
+                    input_stream=source_file.stream,
+                    output_stream=output,
+                    config=config,
+                    file_path=actual_file_path,
+                    disregard_skip=disregard_skip,
+                    extension=extension,
+                )
+                if changed and show_diff:
+                    source_file.stream.seek(0)
+                    output.seek(0)
+                    show_unified_diff(
+                        file_input=source_file.stream.read(),
+                        file_output=output.read(),
+                        file_path=actual_file_path,
+                        output=None if show_diff is True else show_diff,
+                        color_output=config.color_output,
+                    )
+                source_file.stream.close()
 
         except ExistingSyntaxErrors:
             warn(f"{actual_file_path} unable to sort due to existing syntax errors", stacklevel=2)

--- a/isort/api.py
+++ b/isort/api.py
@@ -18,10 +18,12 @@ import contextlib
 import shutil
 import sys
 from collections.abc import Iterator
+from contextlib import AbstractContextManager, nullcontext
 from enum import Enum
 from io import StringIO
 from itertools import chain
 from pathlib import Path
+from threading import Event
 from typing import Any, TextIO, cast
 from warnings import warn
 
@@ -349,21 +351,44 @@ def check_file(
         )
 
 
-def _tmp_file(source_file: File) -> Path:
-    return source_file.path.with_suffix(source_file.path.suffix + ".isorted")
+@contextlib.contextmanager
+def _in_memory_output_stream_context(source_file: File, changed: Event) -> Iterator[TextIO]:
+    """
+    Output stream that is kept in memory.
+
+    If `changed` is set at exit it will copy the stream to the source file.
+    """
+    stream = StringIO(newline=None)
+    yield stream
+
+    if changed.is_set():
+        stream.seek(0)
+        with source_file.path.open("w") as fs:
+            shutil.copyfileobj(stream, fs)
 
 
 @contextlib.contextmanager
-def _in_memory_output_stream_context() -> Iterator[TextIO]:
-    yield StringIO(newline=None)
+def _file_output_stream_context(
+    filename: str | Path, source_file: File, changed: Event
+) -> Iterator[TextIO]:
+    """
+    Output stream that is written to disk, using a "temporary" `.isorted` file.
 
+    If `changed` is set at exit it will replace the source file with the temporary file.
+    """
+    tmp_file = source_file.path.with_suffix(source_file.path.suffix + ".isorted")
 
-@contextlib.contextmanager
-def _file_output_stream_context(filename: str | Path, source_file: File) -> Iterator[TextIO]:
-    tmp_file = _tmp_file(source_file)
-    with tmp_file.open("w+", encoding=source_file.encoding, newline="") as output_stream:
-        shutil.copymode(filename, tmp_file)
-        yield output_stream
+    try:
+        with tmp_file.open("w+", encoding=source_file.encoding, newline="") as output_stream:
+            shutil.copymode(filename, tmp_file)
+            yield output_stream
+
+        if changed.is_set():
+            source_file.stream.close()
+            tmp_file.replace(source_file.path)
+    finally:
+        # Make sure to remove the temporary file, whatever is the outcoming of sorting.
+        tmp_file.unlink(missing_ok=True)
 
 
 # Ignore DeepSource cyclomatic complexity check for this function. It is one
@@ -422,78 +447,52 @@ def sort_file(
                     disregard_skip=disregard_skip,
                     extension=extension,
                 )
-                
-            if output is None:
-                try:
-                    if config.overwrite_in_place:
-                        output_stream_context = _in_memory_output_stream_context()
-                    else:
-                        output_stream_context = _file_output_stream_context(
-                            filename, source_file
-                        )
-                    with output_stream_context as output_stream:
-                        changed = sort_stream(
-                            input_stream=source_file.stream,
-                            output_stream=output_stream,
-                            config=config,
-                            file_path=actual_file_path,
-                            disregard_skip=disregard_skip,
-                            extension=extension,
-                        )
-                        output_stream.seek(0)
-                        if changed:
-                            if show_diff or ask_to_apply:
-                                source_file.stream.seek(0)
-                                show_unified_diff(
-                                    file_input=source_file.stream.read(),
-                                    file_output=output_stream.read(),
-                                    file_path=actual_file_path,
-                                    output=(
-                                        None if show_diff is True else cast(TextIO, show_diff)
-                                    ),
-                                    color_output=config.color_output,
-                                )
-                                if show_diff or (
-                                    ask_to_apply
-                                    and not ask_whether_to_apply_changes_to_file(
-                                        str(source_file.path)
-                                    )
-                                ):
-                                    return False
-                            source_file.stream.close()
-                            if config.overwrite_in_place:
-                                output_stream.seek(0)
-                                with source_file.path.open("w") as fs:
-                                    shutil.copyfileobj(output_stream, fs)
-                    if changed:
-                        if not config.overwrite_in_place:
-                            tmp_file = _tmp_file(source_file)
-                            tmp_file.replace(source_file.path)
-                        if not config.quiet:
-                            print(f"Fixing {source_file.path}")
-                finally:
-                    if not config.overwrite_in_place:  # pragma: no branch
-                        tmp_file = _tmp_file(source_file)
-                        tmp_file.unlink(missing_ok=True)
+
+            # Prepare the output stream. Using the `is_changed_event` we propagate whether the file
+            # should flush the output to the source file.
+            is_changed_event = Event()
+            if output:
+                output_stream_context: AbstractContextManager[TextIO] = nullcontext(output)
+            elif config.overwrite_in_place:
+                output_stream_context = _in_memory_output_stream_context(
+                    source_file, is_changed_event
+                )
             else:
+                output_stream_context = _file_output_stream_context(
+                    filename, source_file, is_changed_event
+                )
+
+            with output_stream_context as output_stream:
                 changed = sort_stream(
                     input_stream=source_file.stream,
-                    output_stream=output,
+                    output_stream=output_stream,
                     config=config,
                     file_path=actual_file_path,
                     disregard_skip=disregard_skip,
                     extension=extension,
                 )
-                if changed and show_diff:
-                    source_file.stream.seek(0)
-                    output.seek(0)
-                    show_unified_diff(
-                        file_input=source_file.stream.read(),
-                        file_output=output.read(),
-                        file_path=actual_file_path,
-                        output=None if show_diff is True else show_diff,
-                        color_output=config.color_output,
-                    )
+                if changed:
+                    if show_diff or ask_to_apply:
+                        output_stream.seek(0)
+                        source_file.stream.seek(0)
+                        show_unified_diff(
+                            file_input=source_file.stream.read(),
+                            file_output=output_stream.read(),
+                            file_path=actual_file_path,
+                            output=(None if show_diff is True else cast(TextIO, show_diff)),
+                            color_output=config.color_output,
+                        )
+                        if show_diff or (
+                            ask_to_apply
+                            and not ask_whether_to_apply_changes_to_file(str(source_file.path))
+                        ):
+                            return False
+
+                    is_changed_event.set()
+
+                    if not config.quiet:
+                        print(f"Fixing {source_file.path}")
+
         except ExistingSyntaxErrors:
             warn(f"{actual_file_path} unable to sort due to existing syntax errors", stacklevel=2)
         except IntroducedSyntaxErrors:  # pragma: no cover

--- a/isort/api.py
+++ b/isort/api.py
@@ -494,8 +494,6 @@ def sort_file(
                         output=None if show_diff is True else show_diff,
                         color_output=config.color_output,
                     )
-                source_file.stream.close()
-
         except ExistingSyntaxErrors:
             warn(f"{actual_file_path} unable to sort due to existing syntax errors", stacklevel=2)
         except IntroducedSyntaxErrors:  # pragma: no cover

--- a/isort/api.py
+++ b/isort/api.py
@@ -363,6 +363,7 @@ def _in_memory_output_stream_context(source_file: File, changed: Event) -> Itera
 
     if changed.is_set():
         stream.seek(0)
+        source_file.stream.close()
         with source_file.path.open("w") as fs:
             shutil.copyfileobj(stream, fs)
 
@@ -493,7 +494,7 @@ def sort_file(
                 ):
                     return False
 
-            if not config.quiet:
+            if not config.quiet and not output:
                 print(f"Fixing {source_file.path}")
 
             is_changed_event.set()


### PR DESCRIPTION
There was a lot of duplicate code in this function.

By moving cleanup to `_file_output_stream_context` and setting `output_stream_context` a bit smarter we can remove a lot of it.