### PR TITLE
Fix #2242: report lines_before_imports-only changes

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -371,6 +371,10 @@ def process(
                     continue
                 if not import_section:
                     output_stream.write("".join(lines_before))
+                made_changes = made_changes or bool(
+                    import_section
+                    and len(lines_before) != _configured_lines_before_imports(config, extension)
+                )
                 lines_before = []
 
             raw_import_section: str = import_section
@@ -515,3 +519,9 @@ def _has_changed(before: str, after: str, line_separator: str, ignore_whitespace
             != remove_whitespace(after, line_separator=line_separator).strip()
         )
     return before.strip() != after.strip()
+
+
+def _configured_lines_before_imports(config: Config, extension: str) -> int:
+    if config.profile == "black" and extension == "pyi":
+        return 1
+    return config.lines_before_imports

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -1904,6 +1904,31 @@ def test_check_code_should_not_false_positive_with_float_to_top_and_add_imports(
     )
 
 
+@pytest.mark.parametrize(
+    ("test_input", "lines_before_imports", "expected_output"),
+    [
+        ("from a import b, x\n\nfoo = 'bar'\n", 1, "\nfrom a import b, x\n\nfoo = 'bar'\n"),
+        ("\nfrom a import b, x\n\nfoo = 'bar'\n", 0, "from a import b, x\n\nfoo = 'bar'\n"),
+    ],
+)
+def test_lines_before_imports_changes_are_reported_issue_2242(
+    test_input: str, lines_before_imports: int, expected_output: str
+) -> None:
+    output = StringIO()
+
+    changed = isort.api.sort_stream(
+        StringIO(test_input),
+        output,
+        lines_before_imports=lines_before_imports,
+    )
+
+    output.seek(0)
+    assert changed
+    assert output.read() == expected_output
+    assert not isort.check_code(test_input, lines_before_imports=lines_before_imports)
+    assert isort.check_code(expected_output, lines_before_imports=lines_before_imports)
+
+
 def test_unrecoverable_exception_on_valid_input_ending_with_backslash_issue_1893():
     """Ensure isort doesn't raise an IndexError on valid input ending with a backslash
     without a trailing newline, as was the case in issue #1893:


### PR DESCRIPTION
Fixes #2242

When `lines_before_imports` is the only requested change, `core.process()` can still return `False` because the buffered blank lines ahead of the import section never participate in the existing `raw_import_section` comparison. That makes `check_code()` return `True` and prevents file-based paths from applying the formatted output.

This change treats a mismatch between the buffered blank lines and the effective `lines_before_imports` count as a change, while keeping the existing `black`/`.pyi` special case. The regression test covers both adding and removing leading blank lines.

Validation:
- `uv run pytest tests/unit/test_regressions.py -q`
- `uv run pytest 'tests/unit/test_isort.py::test_custom_lines_before_import_section[True]' 'tests/unit/test_isort.py::test_custom_lines_before_import_section[False]' -q`
- `uv run pytest tests/unit -q -k 'not test_importable'`
- `uv run ruff check isort tests/unit`
