### PR TITLE
Run Release on release, not on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 ---
 name: Release
 
-"on":
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+([ab][0-9]+)?"
+on:
+  release:
+    types:
+      - published
 
 jobs:
   release:


### PR DESCRIPTION
<img width="384" height="180" alt="Scherm­afbeelding 2026-04-23 om 21 54 04" src="https://github.com/user-attachments/assets/db1a472c-5fbe-458c-8788-fcd76957e841" />

No clue why this doesn't work...

This does work for `pylint` and `astroid`, so let's adopt. I'll go for `9.0.0a2` this time. Sorry for all the confusion, guess we never released an alpha before.