### PR TITLE
Remove unused _ENCODING_PATTERN regex and re import

### DIFF
--- a/isort/io.py
+++ b/isort/io.py
@@ -1,7 +1,6 @@
 """Defines any IO utilities used by isort"""
 
 import dataclasses
-import re
 import tokenize
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -10,8 +9,6 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from isort.exceptions import UnsupportedEncoding
-
-_ENCODING_PATTERN = re.compile(rb"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Hihi! doing some cleanup! 

Found some dead code here .. `_ENCODING_PATTERN` in `isort/io.py` is a compiled regex that is never referenced anywhere in the codebase. Removed along with the now-unused `import re`.                                  
                                                                                                 
Dead code was identified using [Skylos](https://github.com/duriantaco/skylos).