### PR TITLE
Fix broken relative links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ editors](https://github.com/pycqa/isort/wiki/isort-Plugins) to
 quickly sort all your imports. It requires Python 3.10+ to run but
 supports formatting Python 2 code too.
 
-- [Try isort now from your browser!](../docs/quick_start/0.-try.md)
-- [Using black? See the isort and black compatibility guide.](../docs/configuration/black_compatibility.md)
-- [isort has official support for pre-commit!](../docs/configuration/pre-commit.md)
+- [Try isort now from your browser!](docs/quick_start/0.-try.md)
+- [Using black? See the isort and black compatibility guide.](docs/configuration/black_compatibility.md)
+- [isort has official support for pre-commit!](docs/configuration/pre-commit.md)
 
 ![Example Usage](https://raw.github.com/pycqa/isort/main/example.gif)
 
@@ -151,7 +151,7 @@ notified.
 
 You will notice above the \"multi\_line\_output\" setting. This setting
 defines how from imports wrap when they extend past the line\_length
-limit and has [12 possible settings](../docs/configuration/multi_line_output_modes.md).
+limit and has [12 possible settings](docs/configuration/multi_line_output_modes.md).
 
 ## Indentation
 
@@ -204,7 +204,7 @@ the `-e` option into the command line utility.
 isort provides configuration options to change almost every aspect of how
 imports are organized, ordered, or grouped together in sections.
 
-[Click here](../docs/configuration/custom_sections_and_ordering.md) for an overview of all these options.
+[Click here](docs/configuration/custom_sections_and_ordering.md) for an overview of all these options.
 
 ## Skip processing of imports (outside of configuration)
 
@@ -241,7 +241,7 @@ import a
 
 isort can be ran or configured to add / remove imports automatically.
 
-[See a complete guide here.](../docs/configuration/add_or_remove_imports.md)
+[See a complete guide here.](docs/configuration/add_or_remove_imports.md)
 
 ## Using isort to verify code
 
@@ -272,7 +272,7 @@ project.
 isort provides a hook function that can be integrated into your Git
 pre-commit script to check Python code before committing.
 
-[More info here.](../docs/configuration/git_hook.md)
+[More info here.](docs/configuration/git_hook.md)
 
 ## Spread the word
 


### PR DESCRIPTION
## Summary

Fixes #2526

The README contained 7 relative links using `../docs/` paths. Since the README sits at the repository root, GitHub resolves these by stripping the branch segment from the URL — producing `blob/docs/file.md` instead of `blob/main/docs/file.md`, which results in 404s.

## Changes

Replaced all 7 broken occurrences of `../docs/` with `docs/` in `README.md`:

- `docs/quick_start/0.-try.md`
- `docs/configuration/black_compatibility.md`
- `docs/configuration/pre-commit.md`
- `docs/configuration/multi_line_output_modes.md`
- `docs/configuration/custom_sections_and_ordering.md`
- `docs/configuration/add_or_remove_imports.md`
- `docs/configuration/git_hook.md`

## Testing

Documentation-only change. Ran `./scripts/test.sh` — all tests pass.