### PR TITLE
Remove references to defunct `git_ignore` config

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1629,16 +1629,6 @@ Forces star imports above others to avoid overriding directly imported variables
 
 - --star-first
 
-## Git Ignore
-
-If `True` isort will honor ignores within locally defined .git_ignore files.
-
-**Type:** Dict  
-**Default:** `{}`  
-**Config default:** `{}`  
-**Python & Config File Name:** git_ignore  
-**CLI Flags:** **Not Supported**
-
 ## Format Error
 
 Override the format used to print errors.

--- a/scripts/build_config_option_docs.py
+++ b/scripts/build_config_option_docs.py
@@ -128,7 +128,6 @@ description_mapping = {
     "auto_identify_namespace_packages": "Automatically determine local namespace packages, generally by lack of any src files before a src containing directory.",
     "namespace_packages": "Manually specify one or more namespace packages.",
     "follow_links": "If `True` isort will follow symbolic links when doing recursive sorting.",
-    "git_ignore": "If `True` isort will honor ignores within locally defined .git_ignore files.",
     "formatting_function": "The fully qualified Python path of a function to apply to format code sorted by isort.",
     "group_by_package": "If `True` isort will automatically create section groups by the top-level package they come from.",
     "indented_import_headings": "If `True` isort will apply import headings to indented imports the same way it does unindented ones.",


### PR DESCRIPTION
https://pycqa.github.io/isort/docs/configuration/options.html#git-ignore is nonsense and doesn't work - it raises `UnsupportedSettings` because e16806990ed862ac2bdc3125060d1a35741c1e83 removed it without removing the documentation that refers to it.

The remaining config option that still works is `skip_gitignore` https://pycqa.github.io/isort/docs/configuration/options.html#skip-gitignore.

Remove the defunct one to avoid confusion.

Fixes #1920