### PR TITLE
Old docs page should point to the new one.

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -2776,6 +2776,7 @@
                 
                 
                 <h1 id="changelog">Changelog</h1>
+                <h3>⚠️ Docs have moved, see <a href="https://isort.readthedocs.io/en/latest/">https://isort.readthedocs.io/en/latest/</a> for the latest</h3>
 <p>NOTE: isort follows the <a href="https://semver.org/">semver</a> versioning standard.
 Find out more about isort's release policy <a href="https://pycqa.github.io/isort/docs/major_releases/release_policy">here</a>.</p>
 <h3 id="5112-december-12-2022">5.11.2 December 12 2022</h3>

--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -2776,7 +2776,7 @@
                 
                 
                 <h1 id="changelog">Changelog</h1>
-                <h3>⚠️ Docs have moved, see <a href="https://isort.readthedocs.io/en/latest/">https://isort.readthedocs.io/en/latest/</a> for the latest</h3>
+                <h3>⚠️ Docs have moved, see <a href="https://isort.readthedocs.io/en/latest/changelog.html">https://isort.readthedocs.io/en/latest/changelog.html</a> for the latest</h3>
 <p>NOTE: isort follows the <a href="https://semver.org/">semver</a> versioning standard.
 Find out more about isort's release policy <a href="https://pycqa.github.io/isort/docs/major_releases/release_policy">here</a>.</p>
 <h3 id="5112-december-12-2022">5.11.2 December 12 2022</h3>

--- a/index.html
+++ b/index.html
@@ -1594,6 +1594,7 @@
                 
                 
                   <h1>Home</h1>
+                  <h3>⚠️ Docs have moved, see <a href="https://isort.readthedocs.io/en/latest/">https://isort.readthedocs.io/en/latest/</a> for the latest</h3>
                 
                 <p><a href="https://pycqa.github.io/isort/"><img alt="isort - isort your imports, so you don't have to." src="https://raw.githubusercontent.com/pycqa/isort/main/art/logo_large.png" /></a></p>
 <hr />


### PR DESCRIPTION
Possible improvement re https://github.com/PyCQA/isort/issues/2533, assuming that https://pycqa.github.io/isort/ is served up from the `gh-pages` branch (which this PR targets) as I suspect.