### PR TITLE
Fix --resolve-all-configs not using local setting for directly passed files

### DIFF
--- a/isort/api.py
+++ b/isort/api.py
@@ -327,10 +327,11 @@ def check_file(
         config_trie = config_kwargs.pop("config_trie", None)
         if config_trie:
             config_info = config_trie.search(filename)
-            if config.verbose:
+            if config_info[0] and config.verbose:
                 print(f"{config_info[0]} used for file {filename}")
 
-            file_config = Config(**config_info[1])
+            if config_info[0]:
+                file_config = Config(**config_info[1])
 
     with io.File.read(filename) as source_file:
         return check_stream(
@@ -422,10 +423,11 @@ def sort_file(
         config_trie = config_kwargs.pop("config_trie", None)
         if config_trie:
             config_info = config_trie.search(filename)
-            if config.verbose:
+            if config_info[0] and config.verbose:
                 print(f"{config_info[0]} used for file {filename}")
 
-            file_config = Config(**config_info[1])
+            if config_info[0]:
+                file_config = Config(**config_info[1])
 
     with io.File.read(filename) as source_file:
         actual_file_path = file_path or source_file.path

--- a/isort/main.py
+++ b/isort/main.py
@@ -1141,6 +1141,7 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
                         show_diff=show_diff,
                         write_to_stdout=write_to_stdout,
                         extension=ext_format,
+                        disregard_skip=not resolve_all_configs,
                         config_trie=config_trie,
                     ),
                     file_names,
@@ -1156,6 +1157,7 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
                         show_diff=show_diff,
                         write_to_stdout=write_to_stdout,
                         extension=ext_format,
+                        disregard_skip=not resolve_all_configs,
                         config_trie=config_trie,
                     )
                     for file_name in file_names

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -774,7 +774,7 @@ def find_all_configs(path: str) -> Trie:
     Parses and stores any config file encountered in a trie and returns the root of
     the trie
     """
-    trie_root = Trie("default", {})
+    trie_root = Trie("default", {}, root_path=path)
 
     for dirpath, _, _ in os.walk(path):
         for config_file_name in CONFIG_SOURCES:

--- a/isort/utils.py
+++ b/isort/utils.py
@@ -20,8 +20,14 @@ class Trie:
     associated with each file
     """
 
-    def __init__(self, config_file: str = "", config_data: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        config_file: str = "",
+        config_data: dict[str, Any] | None = None,
+        root_path: str = "",
+    ) -> None:
         self.root: TrieNode = TrieNode(config_file, config_data)
+        self.root_path: Path | None = Path(root_path).resolve() if root_path else None
 
     def insert(self, config_file: str, config_data: dict[str, Any]) -> None:
         resolved_config_path_as_tuple = Path(config_file).parent.resolve().parts
@@ -41,7 +47,14 @@ class Trie:
         Returns the closest config relative to filename by doing a depth
         first search on the prefix tree.
         """
-        resolved_file_path_as_tuple = Path(filename).resolve().parts
+        resolved_file_path = Path(filename).resolve()
+        if self.root_path:
+            try:
+                resolved_file_path.relative_to(self.root_path)
+            except ValueError:
+                return ("", {})
+
+        resolved_file_path_as_tuple = resolved_file_path.parts
 
         temp = self.root
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -153,6 +153,22 @@ sections=MADEUP
         main.main([str(python_file)])
 
 
+def test_resolve_all_configs_honors_skip_for_direct_file(tmp_path, capsys):
+    config_file = tmp_path / "pyproject.toml"
+    config_file.write_text("[tool.isort]\nextend_skip = ['a.py']\n")
+    python_file = tmp_path / "a.py"
+    original_content = "import sys\nimport os\n"
+    python_file.write_text(original_content)
+
+    main.main([str(python_file), "--resolve-all-configs", "--verbose"])
+
+    out, error = capsys.readouterr()
+    assert not error
+    assert "default used for file" not in out
+    assert "Skipped 1 files" in out
+    assert python_file.read_text() == original_content
+
+
 def test_ran_against_root():
     with pytest.raises(SystemExit):
         main.main(["/"])


### PR DESCRIPTION
## Summary

  Fixes an issue where files passed directly on the command line could ignore their local isort configuration when "--resolve-all-configs" was enabled.
  When "--resolve-all-configs" was used with its default "--config-root" of ".", and the target file lived outside that config root, the config trie returned the root fallback config as "default". That fallback empty config then replaced the file-specific config that had already been resolved from the file path. As a result, local settings such as extend_skip = ['a.py'] were not applied, and verbose output showed:
  - default used for file /tmp/isort-2335/a.py
  This PR preserves the local file configuration in that case and allows skip settings to take effect when sorting directly passed files with --resolve-all-configs.

## Changes

  - Added root_path tracking to the config Trie used by find_all_configs().
  - Updated config trie lookup so files outside the configured search root return no trie match instead of incorrectly matching the trie root
    fallback.
  - Updated check_file() and sort_file() to replace the active config only when the trie returns an actual config match.
  - Updated CLI sorting with --resolve-all-configs to respect skip settings for directly passed files.
  - Added a regression test covering a directly passed file whose containing directory defines:
 
## Verification

  Ran the focused regression test:
  uv run pytest tests/unit/test_main.py::test_resolve_all_configs_honors_skip_for_direct_file -q 
  Result:
  1 passed

  Ran related CLI tests:
  uv run pytest tests/unit/test_main.py -q
  Result:
  22 passed

  Ran the project unit test script:
  ./scripts/test.sh
  Result:
  571 passed, 1 skipped

  Ran the project clean/format script:
  ./scripts/clean.sh
  Result:
  110 files left unchanged