### PR TITLE
fix(core): detect changes when only lines_before_imports differs

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -516,7 +516,7 @@ def _indented_config(config: Config, indent: str) -> Config:
 def _has_changed(before: str, after: str, line_separator: str, ignore_whitespace: bool) -> bool:
     if ignore_whitespace:
         return (
-            remove_whitespace(before, line_separator=line_separator).strip()
-            != remove_whitespace(after, line_separator=line_separator).strip()
+            remove_whitespace(before, line_separator=line_separator).rstrip()
+            != remove_whitespace(after, line_separator=line_separator).rstrip()
         )
-    return before.strip() != after.strip()
+    return before.rstrip() != after.rstrip()


### PR DESCRIPTION
### Description

`isort.core.process` returns `False` when the only change made is adding blank lines via `lines_before_imports`. The root cause is in `_has_changed()` which uses `.strip()` to compare the before/after import sections — this strips leading blank lines from both sides, making them equal when the only difference is prepended whitespace.

Changed `.strip()` to `.rstrip()` so leading whitespace differences are preserved while trailing newline differences are still ignored. The import section is already `lstrip`-ed of line separators before comparison, so leading whitespace in `before` should only come from `lines_before_imports` additions.

- [x] A short code fix
  - Fixes: #2242
  - Verified with reproduction cases from the issue