### PR TITLE
Fix git_hook lazy=True option

### DIFF
--- a/isort/hooks.py
+++ b/isort/hooks.py
@@ -58,9 +58,10 @@ def git_hook(
 
     :return number of errors if in strict mode, 0 otherwise.
     """
-    # Get list of files modified and staged
+    # Get list of modified files which are staged for commit...
     diff_cmd = ["git", "diff-index", "--cached", "--name-only", "--diff-filter=ACMRTUXB", "HEAD"]
     if lazy:
+        # ...or *all* modified files if lazy=True
         diff_cmd.remove("--cached")
     if directories:
         diff_cmd.extend(directories)
@@ -76,14 +77,19 @@ def git_hook(
     )
     for filename in files_modified:
         if filename.endswith(".py"):
-            # Get the staged contents of the file
-            staged_cmd = ["git", "show", f":{filename}"]
-            staged_contents = get_output(staged_cmd)
-
             try:
-                if not api.check_code_string(
-                    staged_contents, file_path=Path(filename), config=config
-                ):
+                check_passed = False
+                if lazy:
+                    # Check the file as-is on disk
+                    check_passed = api.check_file(filename, config=config)
+                else:
+                    # Read and check the git *staged* contents of the file
+                    staged_cmd = ["git", "show", f":{filename}"]
+                    staged_contents = get_output(staged_cmd)
+                    check_passed = api.check_code_string(
+                        staged_contents, file_path=Path(filename), config=config
+                    )
+                if not check_passed:
                     errors += 1
                     if modify:
                         api.sort_file(filename, config=config)

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -74,6 +74,23 @@ def test_git_hook(src_dir):
                 hooks.git_hook(modify=True)
 
 
+def test_git_hook_lazy(tmpdir):
+    # Write an actual unsorted file to disk & check that `lazy=True` spots it
+
+    has_problems = tmpdir.join("test_has_problems.py")
+    has_problems.write_text("import b\nimport a\n", "utf8")
+
+    # get_lines is called by git_hook to get the list of modified files to be checked
+    with patch("isort.hooks.get_lines", MagicMock(return_value=[str(has_problems)])):
+        with patch("subprocess.run", MagicMock(side_effect=RuntimeError("donotcall"))) as run_mock:
+            found_errors = hooks.git_hook(lazy=True, strict=True)
+            # subprocess.run (via get_output) should not be called when lazy=True
+            # because we're not asking git for the staged content
+            assert run_mock.call_count == 0
+
+    assert found_errors == 1
+
+
 def test_git_hook_uses_the_configuration_file_specified_in_settings_path(tmp_path: Path) -> None:
     subdirectory_path = tmp_path / "subdirectory"
     configuration_file_path = subdirectory_path / ".isort.cfg"


### PR DESCRIPTION
Ensure that passing `lazy=True` to `git_hook` causes it to spot infractions which are not staged.

The whole point of `lazy=True` is to also flag unstaged changes - these files are already discovered (by removing `--cached`) but we also need to check the on-disk copy, not the staged copy otherwise unstaged diffs do not cause isort to fail.

Fixes #2532