### PR TITLE
Fix # isort: off not preserving preceding import section

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -414,6 +414,9 @@ def process(
                 if not contains_imports:
                     output_stream.write(import_section)
 
+                elif stripped_line == "# isort: off":
+                    output_stream.write(raw_import_section)
+
                 else:
                     leading_whitespace = import_section[: -len(import_section.lstrip())]
                     trailing_whitespace = import_section[len(import_section.rstrip()) :]

--- a/tests/unit/test_action_comments.py
+++ b/tests/unit/test_action_comments.py
@@ -26,7 +26,7 @@ import a
 import a
 """
     )
-    # as middle comment
+    # as middle comment — imports before # isort: off are preserved as-is
     assert (
         isort.code(
             """
@@ -39,6 +39,7 @@ import a
 """
         )
         == """
+import a
 import a
 
 # isort: off


### PR DESCRIPTION
Problem: When # isort: off appears after an import section, isort was still sorting/reformatting/deduplicating the imports before the directive — affecting both import and from ... import statements.

Fix: In core.py, when stripped_line == "# isort: off" triggers the import section flush, write raw_import_section (the original unmodified text) instead of the sorted output.

Test: Updated the existing test_isort_off_and_on assertion to reflect corrected behavior (duplicates before # isort: off are now preserved).

Fixes #2528