### PR TITLE
fix: check_code misses lines_before_imports-only changes (#2242)

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -373,12 +373,15 @@ def process(
                     not_imports = True
 
         if not_imports:
+            above_import_section: str = ""
             if not was_in_quote and config.lines_before_imports > -1:
                 if line.strip() == "" and not end_of_file:
                     lines_before += line
                     continue
                 if not import_section:
                     output_stream.write("".join(lines_before))
+                else:
+                    above_import_section = "".join(lines_before)
                 lines_before = []
 
             raw_import_section: str = import_section
@@ -451,7 +454,7 @@ def process(
                             )
 
                         made_changes = made_changes or _has_changed(
-                            before=raw_import_section,
+                            before=above_import_section + raw_import_section,
                             after=sorted_import_section,
                             line_separator=line_separator,
                             ignore_whitespace=config.ignore_whitespace,
@@ -522,4 +525,4 @@ def _has_changed(before: str, after: str, line_separator: str, ignore_whitespace
             remove_whitespace(before, line_separator=line_separator).strip()
             != remove_whitespace(after, line_separator=line_separator).strip()
         )
-    return before.strip() != after.strip()
+    return before.rstrip() != after.rstrip()

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -1703,6 +1703,31 @@ def test_custom_lines_before_import_section(has_body: bool) -> None:
     )
 
 
+def test_check_code_detects_lines_before_import_changes() -> None:
+    """check_code must return False when lines_before_imports requires adding or removing blank
+    lines before the import section, even if the imports themselves are already sorted.
+
+    Regression test for https://github.com/PyCQA/isort/issues/2242
+    """
+    ln = "\n"
+    sorted_imports = "from a import b, x\n"
+    body = "\nfoo = 'bar'\n"
+
+    # Adding a blank line before imports (0 present, 1 required)
+    code_without_blank = sorted_imports + body
+    assert isort.code(code_without_blank, lines_before_imports=1) == ln + code_without_blank
+    assert not isort.check_code(code_without_blank, lines_before_imports=1)
+
+    # Removing a blank line before imports (1 present, 0 required)
+    code_with_blank = ln + sorted_imports + body
+    assert isort.code(code_with_blank, lines_before_imports=0) == sorted_imports + body
+    assert not isort.check_code(code_with_blank, lines_before_imports=0)
+
+    # Already correct: no change needed
+    assert isort.check_code(code_without_blank, lines_before_imports=0)
+    assert isort.check_code(code_with_blank, lines_before_imports=1)
+
+
 def test_custom_lines_after_import_section() -> None:
     """Test the case where the number of lines to output after imports has been explicitly set."""
     test_input = "from a import b\nfoo = 'bar'\n"

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -1709,23 +1709,22 @@ def test_check_code_detects_lines_before_import_changes() -> None:
 
     Regression test for https://github.com/PyCQA/isort/issues/2242
     """
-    ln = "\n"
-    sorted_imports = "from a import b, x\n"
-    body = "\nfoo = 'bar'\n"
+    code = """from a import b, x
+
+foo = 'bar'
+"""
 
     # Adding a blank line before imports (0 present, 1 required)
-    code_without_blank = sorted_imports + body
-    assert isort.code(code_without_blank, lines_before_imports=1) == ln + code_without_blank
-    assert not isort.check_code(code_without_blank, lines_before_imports=1)
+    assert isort.code(code, lines_before_imports=1) == "\n" + code
+    assert not isort.check_code(code, lines_before_imports=1)
 
     # Removing a blank line before imports (1 present, 0 required)
-    code_with_blank = ln + sorted_imports + body
-    assert isort.code(code_with_blank, lines_before_imports=0) == sorted_imports + body
-    assert not isort.check_code(code_with_blank, lines_before_imports=0)
+    assert isort.code("\n" + code, lines_before_imports=0) == code
+    assert not isort.check_code("\n" + code, lines_before_imports=0)
 
     # Already correct: no change needed
-    assert isort.check_code(code_without_blank, lines_before_imports=0)
-    assert isort.check_code(code_with_blank, lines_before_imports=1)
+    assert isort.check_code(code, lines_before_imports=0)
+    assert isort.check_code("\n" + code, lines_before_imports=1)
 
 
 def test_custom_lines_after_import_section() -> None:


### PR DESCRIPTION
## Problem

`isort.check_code` (and `isort.core.process`) returns `True` (no changes needed) when `lines_before_imports` requires adding or removing blank lines before the import block, but the imports themselves are already correctly sorted.

Closes #2242.

```python
import isort

code = "from a import b, x\n\nfoo = 'bar'\n"

# isort.code() correctly adds the blank line:
assert isort.code(code, lines_before_imports=1) == "\n" + code  # ✓

# But check_code incorrectly says no change is needed:
assert isort.check_code(code, lines_before_imports=1)  # ✗ should be False
```

## Root cause

Two cooperating issues in `isort/core.py`:

**1. `_has_changed()` used `.strip()` for comparison** — this stripped leading newlines that `output.sorted_imports` had prepended (via `lines_before_imports`), making additions invisible:

```python
# Before: both sides stripped → leading blank line difference hidden
return before.strip() != after.strip()
```

**2. Blank lines consumed before the import block were excluded from the comparison** — when `lines_before_imports >= 0`, blank lines preceding the import block are buffered in `lines_before` and then discarded (not written to the output stream). The `raw_import_section` passed to `_has_changed` never included those consumed lines, so *removing* them was also never detected as a change.

## Fix

- Change `_has_changed` to use `.rstrip()` instead of `.strip()`, preserving leading whitespace differences while still ignoring insignificant trailing newlines.
- Capture the buffered pre-import blank lines in `above_import_section` and prepend them to `raw_import_section` before the comparison, so removed blank lines are detected.

## Tests

Added `test_check_code_detects_lines_before_import_changes` covering:
- Adding a blank line (0 present → 1 required)
- Removing a blank line (1 present → 0 required)
- Already-correct cases (no false positives)

Note: PR #2541 addresses the same issue with only the `.rstrip()` fix, which handles the "adding blank lines" case. This PR also fixes the "removing blank lines" case via the `above_import_section` addition, and includes the requested test.

This pull request was prepared with the assistance of AI, under my direction and review.