### PR TITLE
Fix pylint disable-next comments detaching from imports at function-body start

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -68,6 +68,7 @@ def process(
     first_comment_index_end: int = -1
     contains_imports: bool = False
     in_top_comment: bool = False
+    top_comment_started: bool = False
     first_import_section: bool = True
     indent: str = ""
     isort_off: bool = False
@@ -195,12 +196,23 @@ def process(
                     ]
 
             if (
-                (index == 0 or (index in {1, 2} and not contains_imports))
+                (
+                    index == 0
+                    or (
+                        index in {1, 2}
+                        and not contains_imports
+                        and (
+                            top_comment_started
+                            or stripped_line.startswith("# isort:")
+                        )
+                    )
+                )
                 and stripped_line.startswith("#")
                 and stripped_line not in config.section_comments
                 and stripped_line not in CODE_SORT_COMMENTS
             ):
                 in_top_comment = True
+                top_comment_started = True
             elif in_top_comment and (
                 not line.startswith("#")
                 or stripped_line in config.section_comments
@@ -303,6 +315,8 @@ def process(
                     and stripped_line not in config.treat_comments_as_code
                 ):
                     import_section += line
+                    if not indent and stripped_line and index < 3 and not top_comment_started:
+                        indent = line[: -len(line.lstrip())]
                 elif stripped_line.startswith(IMPORT_START_IDENTIFIERS):
                     new_indent = line[: -len(line.lstrip())]
                     import_statement = line

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2094,3 +2094,55 @@ def test_noqa_wrap_mode_idempotent_with_existing_comment():
     second_pass = isort.code(first_pass, multi_line_output=7)
     assert second_pass == first_pass
     assert second_pass.count("NOQA") == 1
+
+
+def test_pylint_disable_next_stays_with_import_issue_2054():
+    """pylint disable-next comments should stay associated with their imports after sorting.
+
+    When a function body begins with ``# pylint: disable-next=...`` at the first or second
+    line position, isort was incorrectly treating it as a file-level top comment and writing
+    it to the output before sorting the imports.  Each comment must travel with the specific
+    import that follows it.
+
+    See: https://github.com/PyCQA/isort/issues/2054
+    """
+    test_input = """def foo():
+    # pylint: disable-next=no-name-in-module
+    from C import D
+    # pylint: disable-next=no-name-in-module
+    from A import B
+"""
+    assert isort.code(test_input) == """def foo():
+    # pylint: disable-next=no-name-in-module
+    from A import B
+    # pylint: disable-next=no-name-in-module
+    from C import D
+"""
+
+    # Single comment with one import that sorts after another import
+    test_input_single = """def bar():
+    # pylint: disable-next=no-name-in-module
+    from Z import W
+    import A
+"""
+    assert isort.code(test_input_single) == """def bar():
+    import A
+    # pylint: disable-next=no-name-in-module
+    from Z import W
+"""
+
+    # Comment preceded by a blank line inside the function body
+    test_input_blank = """def baz():
+
+    # pylint: disable-next=no-name-in-module
+    from C import D
+    from A import B
+"""
+    # After sorting, comment stays with the import it annotated (from C import D),
+    # while the unannotated import (from A import B) sorts before it.
+    assert isort.code(test_input_blank) == """def baz():
+
+    from A import B
+    # pylint: disable-next=no-name-in-module
+    from C import D
+"""


### PR DESCRIPTION
## What's the issue?

Closes #2054.

When a function definition appears at the very start of a file (index 0), the first
comment inside the function body (at file-line index 1 or 2) was incorrectly flagged
by the `in_top_comment` mechanism. This caused it to be written directly to the output
stream *before* the import section was sorted, silently breaking
`# pylint: disable-next=...` annotations:

```python
# Before fix – both comments float above all imports
def foo():
    # pylint: disable-next=no-name-in-module   ← detached
    # pylint: disable-next=no-name-in-module   ← detached
    from A import B
    from C import D
```

```python
# After fix – each comment travels with its import
def foo():
    # pylint: disable-next=no-name-in-module
    from A import B
    # pylint: disable-next=no-name-in-module
    from C import D
```

## Root cause

`in_top_comment` fired at indices 1–2 whenever no imports had been seen yet,
regardless of whether the preceding non-blank line was a genuine file header comment
(shebang / coding declaration) or actual code like `def foo():`.

## Fix

Two targeted changes to `isort/core.py`:

1. **`top_comment_started` flag** – set only when a comment at index 0 opens a
   file-level header block.  At indices 1–2, `in_top_comment` now additionally
   requires either `top_comment_started` (header continuation) or a `# isort:`
   directive prefix.  Non-isort comments (e.g. `# pylint:`) inside a function body
   are no longer mistakenly promoted to top comments.

2. **Indent inference from comment** – when a non-top comment at index < 3 enters the
   `import_section` buffer (instead of being written directly), the current `indent` is
   inferred from its leading whitespace.  This prevents a spurious indent-transition
   flush that would otherwise separate the comment from its following import before
   `parse.file_contents` can associate them.

## Existing behaviour preserved

* File-level header comments (shebang, coding, licence) are still handled unchanged.
* Two top-level header comments separated by a blank line still both stay above imports.
* `# isort: dont-add-import:` and other `# isort:` directives at the top of a file
  continue to be treated as file-level control lines.
* Comments that are **not** at the very start of the file (e.g. block headers inside
  functions deeper in the file) retain existing behaviour – the indent-inference applies
  only to the first three file lines.

## Tests

A new regression test `test_pylint_disable_next_stays_with_import_issue_2054` covers:

* Two `# pylint: disable-next` annotations, each before a different import
* A single annotation where the annotated import sorts after an unannotated one
* An annotation preceded by a blank line inside the function body (fix still applies
  at index 2)