### PR TITLE
Preserve form feed blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Find out more about isort's release policy [here](docs/major_releases/release_po
 
 ### Unreleased
 
+  - Preserve form feed characters when they appear on otherwise blank lines (#2562)
+
 ### 8.0.0 February 19 2026 
 
   - Removed `--old-finders` and `--magic-placement` flags and `old_finders` configuration option. The legacy finder logic that relied on environment introspection has been removed (#2445) @joao-faria-dev

--- a/isort/output.py
+++ b/isort/output.py
@@ -132,9 +132,9 @@ def sorted_imports(
 
     if output:
         imports_tail = output_at + len(output)
-        while [
-            character.strip() for character in formatted_output[imports_tail : imports_tail + 1]
-        ] == [""]:
+        while formatted_output[imports_tail : imports_tail + 1] and _is_removable_blank_line(
+            formatted_output[imports_tail]
+        ):
             formatted_output.pop(imports_tail)
 
         if config.lines_before_imports != -1:
@@ -189,6 +189,10 @@ def sorted_imports(
         formatted_output = new_out_lines
 
     return _output_as_string(formatted_output, parsed.line_separator)
+
+
+def _is_removable_blank_line(line: str) -> bool:
+    return "\f" not in line and line.strip() == ""
 
 
 # Ignore DeepSource cyclomatic complexity check for this function.

--- a/isort/parse.py
+++ b/isort/parse.py
@@ -1,5 +1,6 @@
 """Defines parsing functions used by isort for parsing import definitions"""
 
+import re
 from collections import OrderedDict, defaultdict
 from functools import partial
 from itertools import chain
@@ -18,6 +19,8 @@ from ._parse_utils import (
 from .comments import parse as parse_comments
 from .exceptions import MissingSection
 from .settings import DEFAULT_CONFIG, Config
+
+NEWLINE_RE = re.compile(r"\r\n|\r|\n")
 
 if TYPE_CHECKING:
     CommentsAboveDict = TypedDict(
@@ -77,9 +80,7 @@ class ParsedContent(NamedTuple):
 def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedContent:
     """Parses a python file taking out and categorizing imports."""
     line_separator: str = config.line_ending or _infer_line_separator(contents)
-    in_lines = contents.splitlines()
-    if contents and contents[-1] in ("\n", "\r"):
-        in_lines.append("")
+    in_lines = NEWLINE_RE.split(contents) if contents else []
 
     out_lines = []
     original_line_count = len(in_lines)

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -99,6 +99,12 @@ from starlette import status
     assert isort.code(test_input) == test_input
 
 
+def test_form_feed_blank_line_not_removed_issue_2562():
+    """Ensure isort preserves form feed as a valid blank line."""
+    test_input = 'import os\nimport sys\n\n\f\nprint("Hello, world!")\n'
+    assert isort.code(test_input) == test_input
+
+
 def test_extra_blank_line_added_nested_imports_issue_1290():
     """Ensure isort doesn't add unnecessary blank lines above nested imports.
     See: https://github.com/pycqa/isort/issues/1290


### PR DESCRIPTION
`str.splitlines()` treats form feed (`\f`, U+000C) as a line boundary, so parsing a file with a form-feed-only blank line drops the character before output is generated. Later, the import-tail blank-line cleanup also treats any `strip()`-empty line as removable.

This changes parsing to split only on actual newline sequences (`\r\n`, `\r`, `\n`) and keeps import-tail cleanup from removing blank lines that contain form feed. That preserves valid Python blank lines while keeping the existing cleanup for ordinary whitespace-only lines.

fixes #2562

Tests:
- `py -3 -m pytest tests/unit/test_regressions.py::test_form_feed_blank_line_not_removed_issue_2562 tests/unit/test_api.py::test_sort_code_string_mixed_newlines tests/unit/test_isort.py::test_ensure_line_endings_are_preserved_issue_493 tests/unit/test_isort.py::test_line_endings_are_detected_ignoring_whitespace -q`
- `py -3 -m pytest tests/unit/test_regressions.py tests/unit/test_api.py tests/unit/test_isort.py -q`
- `py -3 -m ruff check isort/parse.py isort/output.py tests/unit/test_regressions.py --ignore PLC0207`
- `py -3 -m mypy isort/parse.py isort/output.py`

Note: a full `tests/unit` run produced 569 passed / 5 skipped before failing 4 environment-dependent tests unrelated to this change (example profile/sort plugin entry points and a Windows diff fixture side effect).