### PR TITLE
Docs: clarify that files is a positional CLI arg and cannot be set in…

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1836,7 +1836,10 @@ One or more Python source files that need their imports sorted.
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
-- 
+- (positional argument)
+
+!!! note
+    `files` is a positional CLI argument, not a named option, so it cannot be set in config files like `pyproject.toml` or `.isort.cfg`. To avoid specifying files every time, you can run `isort .` to sort all Python files in the current directory, or use a `Makefile` target or shell alias to wrap your preferred paths.
 
 ## Dont Follow Links
 


### PR DESCRIPTION
Fixes #2231
The files option had a blank CLI flags entry and no explanation of why it isn't supported in config files. This adds a clarifying note explaining that files is a positional CLI argument (not a named option), and suggests workarounds like isort . or a Makefile target.