### PR TITLE
Keep aliased import when the plain name carries a comment

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -556,6 +556,21 @@ def _with_from_imports(
                     comment = (
                         parsed.categorized_comments["nested"].get(module, {}).pop(from_import, None)
                     )
+                    if (
+                        comment is not None
+                        and from_import in as_imports
+                        and config.multi_line_output != wrap.Modes.NOQA  # type: ignore[attr-defined] # noqa: E501
+                    ):
+                        # This name also carries an alias.  The leading-alias loop above emits
+                        # the plain name (with this comment) together with its alias on a later
+                        # pass of the outer ``while``.  Consuming it here would print only the
+                        # plain name and silently drop the alias, so put the comment back and
+                        # leave the name for that loop.  (The NOQA wrap mode appends its own
+                        # per-line suppression and keeps its existing handling.)
+                        parsed.categorized_comments["nested"].setdefault(module, {})[
+                            from_import
+                        ] = comment
+                        continue
                     if comment is not None:
                         # If the comment is a noqa and hanging indent wrapping is used,
                         # keep the name in the main list and hoist the comment to the statement.

--- a/isort/output.py
+++ b/isort/output.py
@@ -559,7 +559,7 @@ def _with_from_imports(
                     if (
                         comment is not None
                         and from_import in as_imports
-                        and config.multi_line_output != wrap.Modes.NOQA  # type: ignore[attr-defined] # noqa: E501
+                        and config.multi_line_output != wrap_modes.WrapModes.NOQA
                     ):
                         # This name also has an alias; the leading-alias loop keeps the two
                         # together on a later pass.  Popping the comment here would drop the

--- a/isort/output.py
+++ b/isort/output.py
@@ -561,12 +561,9 @@ def _with_from_imports(
                         and from_import in as_imports
                         and config.multi_line_output != wrap.Modes.NOQA  # type: ignore[attr-defined] # noqa: E501
                     ):
-                        # This name also carries an alias.  The leading-alias loop above emits
-                        # the plain name (with this comment) together with its alias on a later
-                        # pass of the outer ``while``.  Consuming it here would print only the
-                        # plain name and silently drop the alias, so put the comment back and
-                        # leave the name for that loop.  (The NOQA wrap mode appends its own
-                        # per-line suppression and keeps its existing handling.)
+                        # This name also has an alias; the leading-alias loop keeps the two
+                        # together on a later pass.  Popping the comment here would drop the
+                        # alias, so put it back and leave the name for that loop.
                         parsed.categorized_comments["nested"].setdefault(module, {})[
                             from_import
                         ] = comment

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2386,3 +2386,34 @@ def test_isort_skip_is_honored_with_future_import_issue_2092():
     skip_index = next(i for i, line in enumerate(lines) if "# isort: skip" in line)
     assert lines.index("import ccc") > skip_index  # skip not relocated below the block
     assert isort.code(sorted_interleaved) == sorted_interleaved
+
+
+def test_isort_does_not_drop_aliased_import_when_plain_name_has_a_comment():
+    """A name imported both plainly and with an alias must keep its alias when the plain
+    import carries a trailing comment and another member sorts ahead of it.
+
+    With default settings ``from x import m`` (commented) and ``from x import m as z`` are
+    combined into one module group.  The aliased ``m as z`` is only emitted by the loop that
+    walks the *leading* aliased names, so it is reached only while ``m`` sits at the front of
+    the group.  When a sibling such as ``aaa`` sorts before ``m`` that loop never sees ``m``;
+    the later "name has its own comment" pass then printed ``from x import m  # c`` and
+    removed ``m`` from the group, so ``m as z`` was silently dropped (and the output no longer
+    re-sorted cleanly).  The comment-bearing names that also have an alias must be left for the
+    alias loop instead of being consumed here.
+    """
+    to_sort = "from x import aaa\nfrom x import m  # c\nfrom x import m as z\n"
+    expected = "from x import aaa\nfrom x import m  # c\nfrom x import m as z\n"
+
+    first_pass = isort.code(to_sort)
+    assert first_pass == expected
+    assert "m as z" in first_pass
+
+    # The result must already be a fixpoint - the dropped alias previously only surfaced on
+    # the second run.
+    assert isort.code(first_pass) == first_pass
+
+    # The same holds for a relative (local-folder) import.
+    relative = "from . import bar, one\nfrom . import one as zzz  # NOQA\n"
+    relative_sorted = isort.code(relative)
+    assert "one as zzz" in relative_sorted
+    assert isort.code(relative_sorted) == relative_sorted

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2402,10 +2402,9 @@ def test_isort_does_not_drop_aliased_import_when_plain_name_has_a_comment():
     alias loop instead of being consumed here.
     """
     to_sort = "from x import aaa\nfrom x import m  # c\nfrom x import m as z\n"
-    expected = "from x import aaa\nfrom x import m  # c\nfrom x import m as z\n"
 
     first_pass = isort.code(to_sort)
-    assert first_pass == expected
+    assert first_pass == to_sort
     assert "m as z" in first_pass
 
     # The result must already be a fixpoint - the dropped alias previously only surfaced on

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2389,30 +2389,26 @@ def test_isort_skip_is_honored_with_future_import_issue_2092():
 
 
 def test_isort_does_not_drop_aliased_import_when_plain_name_has_a_comment():
-    """A name imported both plainly and with an alias must keep its alias when the plain
-    import carries a trailing comment and another member sorts ahead of it.
+    """A name imported both plainly (with a trailing comment) and aliased must keep its
+    alias when a sibling sorts ahead of it.
 
-    With default settings ``from x import m`` (commented) and ``from x import m as z`` are
-    combined into one module group.  The aliased ``m as z`` is only emitted by the loop that
-    walks the *leading* aliased names, so it is reached only while ``m`` sits at the front of
-    the group.  When a sibling such as ``aaa`` sorts before ``m`` that loop never sees ``m``;
-    the later "name has its own comment" pass then printed ``from x import m  # c`` and
-    removed ``m`` from the group, so ``m as z`` was silently dropped (and the output no longer
-    re-sorted cleanly).  The comment-bearing names that also have an alias must be left for the
-    alias loop instead of being consumed here.
+    ``from x import m  # c`` and ``from x import m as z`` combine into one group, and the
+    alias is only emitted while ``m`` leads that group.  When ``aaa`` sorts before ``m`` the
+    comment pass used to consume ``m`` and drop ``m as z``, which only surfaced on a second
+    run once the group was re-sorted.
     """
     to_sort = "from x import aaa\nfrom x import m  # c\nfrom x import m as z\n"
 
     first_pass = isort.code(to_sort)
     assert first_pass == to_sort
-    assert "m as z" in first_pass
 
-    # The result must already be a fixpoint - the dropped alias previously only surfaced on
-    # the second run.
+    # The dropped alias previously only surfaced on the second run, so the result must
+    # already be a fixpoint.
     assert isort.code(first_pass) == first_pass
 
     # The same holds for a relative (local-folder) import.
     relative = "from . import bar, one\nfrom . import one as zzz  # NOQA\n"
     relative_sorted = isort.code(relative)
-    assert "one as zzz" in relative_sorted
+    expected = "from . import bar\nfrom . import one  # NOQA\nfrom . import one as zzz\n"
+    assert relative_sorted == expected
     assert isort.code(relative_sorted) == relative_sorted

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2398,13 +2398,7 @@ def test_isort_does_not_drop_aliased_import_when_plain_name_has_a_comment():
     run once the group was re-sorted.
     """
     to_sort = "from x import aaa\nfrom x import m  # c\nfrom x import m as z\n"
-
-    first_pass = isort.code(to_sort)
-    assert first_pass == to_sort
-
-    # The dropped alias previously only surfaced on the second run, so the result must
-    # already be a fixpoint.
-    assert isort.code(first_pass) == first_pass
+    assert isort.code(first_pass) == to_sort
 
     # The same holds for a relative (local-folder) import.
     relative = "from . import bar, one\nfrom . import one as zzz  # NOQA\n"

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2398,7 +2398,7 @@ def test_isort_does_not_drop_aliased_import_when_plain_name_has_a_comment():
     run once the group was re-sorted.
     """
     to_sort = "from x import aaa\nfrom x import m  # c\nfrom x import m as z\n"
-    assert isort.code(first_pass) == to_sort
+    assert isort.code(to_sort) == to_sort
 
     # The same holds for a relative (local-folder) import.
     relative = "from . import bar, one\nfrom . import one as zzz  # NOQA\n"


### PR DESCRIPTION
I hit a case where isort silently drops an import. With default settings:

```python
from x import aaa
from x import m  # c
from x import m as z
```

becomes

```python
from x import m  # c
from x import aaa
```

`m as z` is gone, and the output no longer re-sorts to itself.

The trigger is a name imported both plainly and with an alias, where the plain import has a trailing comment and another member of the module sorts ahead of it. The loop that emits aliased names only does so while the name is at the front of the group, so it never reaches one a sibling sorted before. The later "this name has its own comment" pass then prints just the plain name and removes it from the group, dropping the alias with it.

Fix is to leave a commented name that also has an alias for the alias loop rather than consuming it there. Added a regression test; full test suite, mypy, ruff/flake8 and the isort self-check are green.