### PR TITLE
improve coverage

### DIFF
--- a/tests/unit/test_literal.py
+++ b/tests/unit/test_literal.py
@@ -26,3 +26,17 @@ def test_value_assignment_assignments():
 def test_assignments_invalid_section():
     with pytest.raises(exceptions.AssignmentsFormatMismatch):
         isort.literal.assignment("\n\nx = 1\nx++", "assignments", "py")
+
+
+def test_value_assignment_dict():
+    assert (
+        isort.literal.assignment("x = {3: 'c', 1: 'a', 2: 'b'}", "dict", "py")
+        == "x = {1: 'a', 2: 'b', 3: 'c'}"
+    )
+
+
+def test_value_assignment_unique_tuple():
+    assert (
+        isort.literal.assignment("x = ('a', 'b', '1', '1')", "unique-tuple", "py")
+        == "x = ('1', 'a', 'b')"
+    )


### PR DESCRIPTION
Improve coverage in `literal.py` from `95%` to `97%`. 

Added 2 tests case:

- test_value_assignment_dict
- test_value_assignment_unique_tuple

Before:

```
Name                        Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------
isort/literal.py               64      3     14      1    95%   66, 90, 115
```

After:

```
Name                        Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------
isort/literal.py               64      1     14      1    97%   66
```