### PR TITLE
fix: make sorted __all__ and literals black-compatible (#2280)

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -153,7 +153,7 @@ def process(
                 if is_reexport:
                     # Clamp to 0: in check mode the output is a no-op stream whose tell()
                     # stays 0, so an unclamped rollback would seek to a negative position
-                    # and raise ValueError. See issue #2280.
+                    # and raise ValueError. See PR #2576.
                     output_stream.seek(max(0, output_stream.tell() - reexport_rollback))
                     reexport_rollback = 0
                 sorted_code = textwrap.indent(
@@ -280,7 +280,7 @@ def process(
                         )
                         if is_reexport:
                             # Clamp to 0 so check mode's no-op output stream (tell() == 0)
-                            # cannot produce a negative seek position. See issue #2280.
+                            # cannot produce a negative seek position. See PR #2576.
                             output_stream.seek(max(0, output_stream.tell() - reexport_rollback))
                             reexport_rollback = 0
                         output_stream.write(sorted_code)

--- a/isort/core.py
+++ b/isort/core.py
@@ -151,7 +151,10 @@ def process(
 
             if code_sorting and code_sorting_section:
                 if is_reexport:
-                    output_stream.seek(output_stream.tell() - reexport_rollback)
+                    # Clamp to 0: in check mode the output is a no-op stream whose tell()
+                    # stays 0, so an unclamped rollback would seek to a negative position
+                    # and raise ValueError. See issue #2280.
+                    output_stream.seek(max(0, output_stream.tell() - reexport_rollback))
                     reexport_rollback = 0
                 sorted_code = textwrap.indent(
                     isort.literal.assignment(
@@ -276,7 +279,9 @@ def process(
                             ignore_whitespace=config.ignore_whitespace,
                         )
                         if is_reexport:
-                            output_stream.seek(output_stream.tell() - reexport_rollback)
+                            # Clamp to 0 so check mode's no-op output stream (tell() == 0)
+                            # cannot produce a negative seek position. See issue #2280.
+                            output_stream.seek(max(0, output_stream.tell() - reexport_rollback))
                             reexport_rollback = 0
                         output_stream.write(sorted_code)
                         if is_reexport:

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -79,7 +79,8 @@ def register_type(
 def _black_quote(value: str) -> str:
     """Quote a string the way black does: prefer double quotes, fall back to single
     only when it avoids escaping. Values with backslashes or control characters defer
-    to repr() so requoting can never produce invalid source."""
+    to repr() so requoting can never produce invalid source.
+    """
     if any(char in value for char in ("\\", "\n", "\r", "\t")):
         # deliberate: repr() sacrifices black-quote-normalization here to guarantee valid source
         return repr(value)
@@ -91,6 +92,9 @@ def _black_quote(value: str) -> str:
 
 
 def _repr_element(value: Any) -> str:
+    """Render a single sorted element: strings via black's quote rule, everything else
+    via repr() (so ints and other literals in ``# isort: list`` etc. keep working).
+    """
     if isinstance(value, str):
         return _black_quote(value)
     return repr(value)

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -1,6 +1,5 @@
 import ast
 from collections.abc import Callable
-from pprint import PrettyPrinter
 from typing import Any
 
 from isort.exceptions import (
@@ -10,15 +9,7 @@ from isort.exceptions import (
 )
 from isort.settings import DEFAULT_CONFIG, Config
 
-
-class ISortPrettyPrinter(PrettyPrinter):
-    """an isort customized pretty printer for sorted literals"""
-
-    def __init__(self, config: Config):
-        super().__init__(width=config.line_length, compact=True)
-
-
-type_mapping: dict[str, tuple[type, Callable[[Any, ISortPrettyPrinter], str]]] = {}
+type_mapping: dict[str, tuple[type, Callable[[Any, Config, int], str]]] = {}
 
 
 def assignments(code: str) -> str:
@@ -60,8 +51,8 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
     if type(value) is not expected_type:
         raise LiteralSortTypeMismatch(type(value), expected_type)
 
-    printer = ISortPrettyPrinter(config)
-    sorted_value_code = f"{variable_name} = {sort_function(value, printer)}"
+    prefix_length = len(f"{variable_name} = ")
+    sorted_value_code = f"{variable_name} = {sort_function(value, config, prefix_length)}"
     if config.formatting_function:
         sorted_value_code = config.formatting_function(
             sorted_value_code, extension, config
@@ -73,43 +64,100 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
 
 def register_type(
     name: str, kind: type
-) -> Callable[[Callable[[Any, ISortPrettyPrinter], str]], Callable[[Any, ISortPrettyPrinter], str]]:
+) -> Callable[[Callable[[Any, Config, int], str]], Callable[[Any, Config, int], str]]:
     """Registers a new literal sort type."""
 
     def wrap(
-        function: Callable[[Any, ISortPrettyPrinter], str],
-    ) -> Callable[[Any, ISortPrettyPrinter], str]:
+        function: Callable[[Any, Config, int], str],
+    ) -> Callable[[Any, Config, int], str]:
         type_mapping[name] = (kind, function)
         return function
 
     return wrap
 
 
+def _black_quote(value: str) -> str:
+    """Quote a string the way black does: prefer double quotes, fall back to single
+    only when it avoids escaping. Values with backslashes or control characters defer
+    to repr() so requoting can never produce invalid source."""
+    if any(char in value for char in ("\\", "\n", "\r", "\t")):
+        # deliberate: repr() sacrifices black-quote-normalization here to guarantee valid source
+        return repr(value)
+    if '"' in value and "'" not in value:
+        return f"'{value}'"
+    if '"' not in value:
+        return f'"{value}"'
+    return '"' + value.replace('"', '\\"') + '"'
+
+
+def _repr_element(value: Any) -> str:
+    if isinstance(value, str):
+        return _black_quote(value)
+    return repr(value)
+
+
+def _format_collection(
+    elements: list[str],
+    open_bracket: str,
+    close_bracket: str,
+    config: Config,
+    prefix_length: int,
+    single_element_comma: bool = False,
+) -> str:
+    """Render already-rendered, sorted ``elements`` as ``open ... close`` honoring the
+    config: a single line when it fits within ``line_length`` (accounting for the
+    ``prefix_length`` of the ``<name> = `` prefix), otherwise a vertical-hanging-indent
+    block. ``single_element_comma`` forces the mandatory trailing comma that a
+    one-element tuple needs to stay a tuple.
+    """
+    only_element_needs_comma = single_element_comma and len(elements) == 1
+    inner = ", ".join(elements)
+    if only_element_needs_comma:
+        inner += ","
+    single_line = f"{open_bracket}{inner}{close_bracket}"
+    if prefix_length + len(single_line) <= config.line_length:
+        return single_line
+
+    indent = config.indent
+    trailing = "," if (config.include_trailing_comma or only_element_needs_comma) else ""
+    body = (",\n" + indent).join(elements)
+    return f"{open_bracket}\n{indent}{body}{trailing}\n{close_bracket}"
+
+
 @register_type("dict", dict)
-def _dict(value: dict[Any, Any], printer: ISortPrettyPrinter) -> str:
-    return printer.pformat(dict(sorted(value.items(), key=lambda item: item[1])))
+def _dict(value: dict[Any, Any], config: Config, prefix_length: int) -> str:
+    items = [
+        f"{_repr_element(key)}: {_repr_element(item)}"
+        for key, item in sorted(value.items(), key=lambda item: item[1])
+    ]
+    return _format_collection(items, "{", "}", config, prefix_length)
 
 
 @register_type("list", list)
-def _list(value: list[Any], printer: ISortPrettyPrinter) -> str:
-    return printer.pformat(sorted(value))
+def _list(value: list[Any], config: Config, prefix_length: int) -> str:
+    elements = [_repr_element(item) for item in sorted(value)]
+    return _format_collection(elements, "[", "]", config, prefix_length)
 
 
 @register_type("unique-list", list)
-def _unique_list(value: list[Any], printer: ISortPrettyPrinter) -> str:
-    return printer.pformat(sorted(set(value)))
+def _unique_list(value: list[Any], config: Config, prefix_length: int) -> str:
+    elements = [_repr_element(item) for item in sorted(set(value))]
+    return _format_collection(elements, "[", "]", config, prefix_length)
 
 
 @register_type("set", set)
-def _set(value: set[Any], printer: ISortPrettyPrinter) -> str:
-    return "{" + printer.pformat(tuple(sorted(value)))[1:-1] + "}"
+def _set(value: set[Any], config: Config, prefix_length: int) -> str:
+    elements = [_repr_element(item) for item in sorted(value)]
+    return _format_collection(elements, "{", "}", config, prefix_length)
 
 
 @register_type("tuple", tuple)
-def _tuple(value: tuple[Any, ...], printer: ISortPrettyPrinter) -> str:
-    return printer.pformat(tuple(sorted(value)))
+def _tuple(value: tuple[Any, ...], config: Config, prefix_length: int) -> str:
+    elements = [_repr_element(item) for item in sorted(value)]
+    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True)
 
 
 @register_type("unique-tuple", tuple)
-def _unique_tuple(value: tuple[Any, ...], printer: ISortPrettyPrinter) -> str:
-    return printer.pformat(tuple(sorted(set(value))))
+def _unique_tuple(value: tuple[Any, ...], config: Config, prefix_length: int) -> str:
+    elements = [_repr_element(item) for item in sorted(set(value))]
+    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True)

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5574,7 +5574,7 @@ def test_infinite_loop_in_unmatched_parenthesis() -> None:
 def test_reexport() -> None:
     test_input = """__all__ = ('foo', 'bar')
 """
-    expd_output = """__all__ = ('bar', 'foo')
+    expd_output = """__all__ = ("bar", "foo")
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5591,7 +5591,7 @@ def test_reexport_multiline() -> None:
     'bar',
 )
 """
-    expd_output = """__all__ = ('bar', 'foo')
+    expd_output = """__all__ = ("bar", "foo")
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5599,7 +5599,7 @@ def test_reexport_multiline() -> None:
 def test_reexport_list() -> None:
     test_input = """__all__ = ['foo', 'bar']
 """
-    expd_output = """__all__ = ['bar', 'foo']
+    expd_output = """__all__ = ["bar", "foo"]
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5607,7 +5607,7 @@ def test_reexport_list() -> None:
 def test_reexport_set() -> None:
     test_input = """__all__ = {'foo', 'bar'}
 """
-    expd_output = """__all__ = {'bar', 'foo'}
+    expd_output = """__all__ = {"bar", "foo"}
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5615,7 +5615,7 @@ def test_reexport_set() -> None:
 def test_reexport_bare() -> None:
     test_input = """__all__ = 'foo', 'bar'
 """
-    expd_output = """__all__ = ('bar', 'foo')
+    expd_output = """__all__ = ("bar", "foo")
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5623,7 +5623,7 @@ def test_reexport_bare() -> None:
 def test_reexport_no_spaces() -> None:
     test_input = """__all__=('foo', 'bar')
 """
-    expd_output = """__all__ = ('bar', 'foo')
+    expd_output = """__all__ = ("bar", "foo")
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5635,7 +5635,7 @@ def test_reexport_not_first_line() -> None:
 """
     expd_output = """import random
 
-    __all__ = ('bar', 'foo')
+    __all__ = ("bar", "foo")
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5645,7 +5645,7 @@ def test_reexport_not_last_line() -> None:
 
     meme = "rickroll"
 """
-    expd_output = """__all__ = ('bar', 'foo')
+    expd_output = """__all__ = ("bar", "foo")
 
     meme = "rickroll"
 """
@@ -5664,7 +5664,7 @@ __all__ = [
 """
     expd_output = """from m import bar, foo
 
-__all__ = ['bar', 'foo']
+__all__ = ["bar", "foo"]
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5683,7 +5683,7 @@ test
 """
     expd_output = """from m import bar, foo
 
-__all__ = ['bar', 'foo']
+__all__ = ["bar", "foo"]
 
 test
 """
@@ -5700,7 +5700,7 @@ test
 """
     expd_output = """from m import bar, foo
 
-__all__ = ['bar', 'foo']
+__all__ = ["bar", "foo"]
 
 test
 """

--- a/tests/unit/test_literal.py
+++ b/tests/unit/test_literal.py
@@ -1,7 +1,9 @@
 import pytest
 
+import isort
 import isort.literal
 from isort import exceptions
+from isort.settings import Config
 
 
 def test_value_mismatch():
@@ -26,3 +28,97 @@ def test_value_assignment_assignments():
 def test_assignments_invalid_section():
     with pytest.raises(exceptions.AssignmentsFormatMismatch):
         isort.literal.assignment("\n\nx = 1\nx++", "assignments", "py")
+
+
+def test_list_uses_double_quotes():
+    assert isort.literal.assignment("x = ['b', 'a']", "list", "py") == 'x = ["a", "b"]'
+
+
+def test_list_preserves_bracket_type_tuple():
+    assert isort.literal.assignment("x = ('b', 'a')", "tuple", "py") == 'x = ("a", "b")'
+
+
+def test_single_element_tuple_keeps_trailing_comma():
+    assert isort.literal.assignment("x = ('a',)", "tuple", "py") == 'x = ("a",)'
+
+
+def test_set_bracket_and_quotes():
+    assert isort.literal.assignment("x = {'b', 'a'}", "set", "py") == 'x = {"a", "b"}'
+
+
+def test_long_list_wraps_vertical_hanging_indent():
+    code = (
+        "__all__ = ['" + "', '".join(f"name_{i:02d}" for i in range(12)) + "']"
+    )
+    result = isort.literal.assignment(code, "list", "py", config=Config(profile="black"))
+    expected = "__all__ = [\n" + "".join(
+        f'    "name_{i:02d}",\n' for i in range(12)
+    ) + "]"
+    assert result == expected
+
+
+def test_wrap_without_trailing_comma():
+    code = "__all__ = ['" + "', '".join(f"name_{i:02d}" for i in range(12)) + "']"
+    result = isort.literal.assignment(
+        code, "list", "py", config=Config(line_length=20, include_trailing_comma=False)
+    )
+    assert result.endswith('"name_11"\n]')  # no trailing comma before the closing bracket
+
+
+def test_quote_fallback_for_embedded_quote():
+    # value containing a double quote but no single quote -> single quotes (black rule)
+    assert isort.literal.assignment('x = [\'a"b\']', "list", "py") == "x = ['a\"b']"
+
+
+def test_black_quote_prefers_double_quotes():
+    assert isort.literal._black_quote("foo") == '"foo"'
+
+
+def test_black_quote_uses_single_when_value_has_double_quote_only():
+    assert isort.literal._black_quote('a"b') == "'a\"b'"
+
+
+def test_black_quote_escapes_double_when_value_has_both_quotes():
+    assert isort.literal._black_quote("a'b\"c") == '"a\'b\\"c"'
+
+
+def test_black_quote_falls_back_to_repr_for_control_chars():
+    assert isort.literal._black_quote("a\tb") == repr("a\tb")
+
+
+def test_list_of_non_strings_uses_repr():
+    assert isort.literal.assignment("x = [3, 1, 2]", "list", "py") == "x = [1, 2, 3]"
+
+
+def test_unique_tuple_dedupes_and_sorts():
+    assert isort.literal.assignment("x = ('b', 'a', 'a')", "unique-tuple", "py") == 'x = ("a", "b")'
+
+
+def test_single_element_tuple_wraps_and_keeps_comma():
+    long_name = "z" * 100
+    result = isort.literal.assignment(f"x = ('{long_name}',)", "tuple", "py")
+    assert result == f'x = (\n    "{long_name}",\n)'
+
+
+def test_dict_sorts_by_value_with_double_quotes():
+    # dict is now formatted config-aware too (no more pprint); sorted by value
+    assert (
+        isort.literal.assignment("x = {'a': 'z', 'b': 'y'}", "dict", "py")
+        == 'x = {"b": "y", "a": "z"}'
+    )
+
+
+def test_dict_non_string_values_use_repr():
+    assert (
+        isort.literal.assignment("x = {'b': 2, 'a': 1}", "dict", "py") == 'x = {"a": 1, "b": 2}'
+    )
+
+
+def test_long_dict_wraps_vertical_hanging_indent():
+    pairs = {f"key_{i:02d}": f"value_{i:02d}" for i in range(10)}
+    code = "d = {" + ", ".join(f"'{k}': '{v}'" for k, v in pairs.items()) + "}"
+    result = isort.literal.assignment(code, "dict", "py", config=Config(profile="black"))
+    expected = "d = {\n" + "".join(
+        f'    "key_{i:02d}": "value_{i:02d}",\n' for i in range(10)
+    ) + "}"
+    assert result == expected

--- a/tests/unit/test_literal.py
+++ b/tests/unit/test_literal.py
@@ -47,13 +47,9 @@ def test_set_bracket_and_quotes():
 
 
 def test_long_list_wraps_vertical_hanging_indent():
-    code = (
-        "__all__ = ['" + "', '".join(f"name_{i:02d}" for i in range(12)) + "']"
-    )
+    code = "__all__ = ['" + "', '".join(f"name_{i:02d}" for i in range(12)) + "']"
     result = isort.literal.assignment(code, "list", "py", config=Config(profile="black"))
-    expected = "__all__ = [\n" + "".join(
-        f'    "name_{i:02d}",\n' for i in range(12)
-    ) + "]"
+    expected = "__all__ = [\n" + "".join(f'    "name_{i:02d}",\n' for i in range(12)) + "]"
     assert result == expected
 
 
@@ -67,7 +63,7 @@ def test_wrap_without_trailing_comma():
 
 def test_quote_fallback_for_embedded_quote():
     # value containing a double quote but no single quote -> single quotes (black rule)
-    assert isort.literal.assignment('x = [\'a"b\']', "list", "py") == "x = ['a\"b']"
+    assert isort.literal.assignment("x = ['a\"b']", "list", "py") == "x = ['a\"b']"
 
 
 def test_black_quote_prefers_double_quotes():
@@ -109,18 +105,16 @@ def test_dict_sorts_by_value_with_double_quotes():
 
 
 def test_dict_non_string_values_use_repr():
-    assert (
-        isort.literal.assignment("x = {'b': 2, 'a': 1}", "dict", "py") == 'x = {"a": 1, "b": 2}'
-    )
+    assert isort.literal.assignment("x = {'b': 2, 'a': 1}", "dict", "py") == 'x = {"a": 1, "b": 2}'
 
 
 def test_long_dict_wraps_vertical_hanging_indent():
     pairs = {f"key_{i:02d}": f"value_{i:02d}" for i in range(10)}
     code = "d = {" + ", ".join(f"'{k}': '{v}'" for k, v in pairs.items()) + "}"
     result = isort.literal.assignment(code, "dict", "py", config=Config(profile="black"))
-    expected = "d = {\n" + "".join(
-        f'    "key_{i:02d}": "value_{i:02d}",\n' for i in range(10)
-    ) + "}"
+    expected = (
+        "d = {\n" + "".join(f'    "key_{i:02d}": "value_{i:02d}",\n' for i in range(10)) + "}"
+    )
     assert result == expected
 
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2160,12 +2160,17 @@ def test_literal_dict_sort_respects_black_profile_issue_2280():
     and must likewise honor the black profile rather than stdlib ``pprint`` (which produced
     single quotes, pprint-style wrapping and no trailing comma). Same root cause as #2280.
     """
-    test_input = "# isort: dict\n" + "d = {" + ", ".join(
-        f"'key_{i:02d}': 'value_{i:02d}'" for i in (3, 1, 2, 0)
-    ) + "}\n"
-    expected_output = "# isort: dict\nd = {\n" + "".join(
-        f'    "key_{i:02d}": "value_{i:02d}",\n' for i in range(4)
-    ) + "}\n"
+    test_input = (
+        "# isort: dict\n"
+        + "d = {"
+        + ", ".join(f"'key_{i:02d}': 'value_{i:02d}'" for i in (3, 1, 2, 0))
+        + "}\n"
+    )
+    expected_output = (
+        "# isort: dict\nd = {\n"
+        + "".join(f'    "key_{i:02d}": "value_{i:02d}",\n' for i in range(4))
+        + "}\n"
+    )
     assert isort.code(test_input, profile="black") == expected_output
 
 
@@ -2175,9 +2180,11 @@ def test_sort_reexports_output_is_black_stable_issue_2280():
     import black  # noqa: PLC0415
     from black.report import NothingChanged  # noqa: PLC0415
 
-    source = "__all__ = [\n" + "".join(
-        f'    "Name{i:02d}",\n' for i in (5, 3, 9, 1, 7, 2, 8, 4, 6, 0)
-    ) + "]\n"
+    source = (
+        "__all__ = [\n"
+        + "".join(f'    "Name{i:02d}",\n' for i in (5, 3, 9, 1, 7, 2, 8, 4, 6, 0))
+        + "]\n"
+    )
 
     first = isort.code(source, profile="black", sort_reexports=True)
     # isort is idempotent

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -1877,7 +1877,7 @@ class Bar:
         == '''"""I'm a docstring! Look at me!"""
 
 # isort: unique-list
-__all__ = ['Bar', 'Foo']
+__all__ = ["Bar", "Foo"]
 
 from typing import final  # arbitrary
 
@@ -2117,3 +2117,74 @@ def test_noqa_wrap_mode_does_not_accumulate_spaces_with_as_import():
         first_pass, multi_line_output=7, force_single_line=True, line_length=40
     )
     assert second_pass == first_pass
+
+
+def test_sort_reexports_respects_black_profile_issue_2280():
+    """``--sort-reexports`` must honor the active formatting config, not stdlib ``pprint``.
+
+    ``isort.literal`` used to format the sorted ``__all__`` with stdlib ``pprint``, which
+    only reads ``config.line_length`` and ignores ``include_trailing_comma`` and the quote
+    style entirely.  So a long ``__all__`` under ``--profile=black`` came back
+    single-quoted, wrapped in ``pprint`` style (a bare continuation line prefixed with one
+    space) and without a trailing comma - output that black immediately reformats.  See
+    issue #2280: https://github.com/pycqa/isort/issues/2280
+
+    The sorted list must instead match what black itself produces: one element per line,
+    double quotes, a trailing comma and a hanging-indented closing bracket.
+    """
+    test_input = """__all__ = [
+    "AliasAddress",
+    "Address",
+    "BankAccountConnection",
+    "Certificate",
+    "ConcessionFee",
+    "ContactDetails",
+    "Determination",
+]
+"""
+    expected_output = """__all__ = [
+    "Address",
+    "AliasAddress",
+    "BankAccountConnection",
+    "Certificate",
+    "ConcessionFee",
+    "ContactDetails",
+    "Determination",
+]
+"""
+    assert isort.code(test_input, profile="black", sort_reexports=True) == expected_output
+
+
+def test_literal_dict_sort_respects_black_profile_issue_2280():
+    """The ``# isort: dict`` literal sort shares the same formatter as ``--sort-reexports``
+    and must likewise honor the black profile rather than stdlib ``pprint`` (which produced
+    single quotes, pprint-style wrapping and no trailing comma). Same root cause as #2280.
+    """
+    test_input = "# isort: dict\n" + "d = {" + ", ".join(
+        f"'key_{i:02d}': 'value_{i:02d}'" for i in (3, 1, 2, 0)
+    ) + "}\n"
+    expected_output = "# isort: dict\nd = {\n" + "".join(
+        f'    "key_{i:02d}": "value_{i:02d}",\n' for i in range(4)
+    ) + "}\n"
+    assert isort.code(test_input, profile="black") == expected_output
+
+
+def test_sort_reexports_output_is_black_stable_issue_2280():
+    """isort's sorted __all__ under the black profile must be a fixpoint for both isort
+    and black (running either again changes nothing). See issue #2280."""
+    import black  # noqa: PLC0415
+    from black.report import NothingChanged  # noqa: PLC0415
+
+    source = "__all__ = [\n" + "".join(
+        f'    "Name{i:02d}",\n' for i in (5, 3, 9, 1, 7, 2, 8, 4, 6, 0)
+    ) + "]\n"
+
+    first = isort.code(source, profile="black", sort_reexports=True)
+    # isort is idempotent
+    assert isort.code(first, profile="black", sort_reexports=True) == first
+    # black leaves isort's output unchanged
+    try:
+        black_out = black.format_file_contents(first, fast=True, mode=black.FileMode())
+    except NothingChanged:
+        black_out = first
+    assert black_out == first

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2190,6 +2190,26 @@ def test_sort_reexports_output_is_black_stable_issue_2280():
     assert black_out == first
 
 
+def test_sort_reexports_check_mode_multiline_all_issue_2280():
+    """``--check`` on a multi-line ``__all__`` with ``--sort-reexports`` must not crash.
+
+    Check mode routes output to a null stream whose ``tell()`` is always 0. The reexport
+    handling used ``output_stream.seek(output_stream.tell() - len(first_line))`` to roll
+    back over the opening line, which went negative and raised ``ValueError: Negative seek
+    position``. Our black-compatible formatter emits multi-line ``__all__``, so ``isort
+    --check`` began crashing on isort's own output. See issue #2280.
+    """
+    # already-sorted, black-formatted multi-line __all__ (what isort itself now produces)
+    sorted_all = "__all__ = [\n" + "".join(f'    "Name{i:02d}",\n' for i in range(9)) + "]\n"
+    # check must report "no changes" without raising, in both string and stream forms
+    assert isort.check_code(sorted_all, show_diff=False, profile="black", sort_reexports=True)
+
+    # and with imports before it (the realistic module case)
+    with_imports = "from .core import A\n\n" + sorted_all
+    checked = isort.code(with_imports, profile="black", sort_reexports=True)
+    assert isort.check_code(checked, show_diff=False, profile="black", sort_reexports=True)
+
+
 def test_noqa_added_to_long_force_single_line_as_import_with_comment_issue_2093():
     """A long ``as`` import with inline comment must get ``# NOQA`` in NOQA mode.
 


### PR DESCRIPTION
Resolves: #2280, #1815

## Problem
`--sort-reexports` (and the `# isort: list/dict/tuple/…` comments) format the sorted result with stdlib `pprint`. Under `--profile=black` the result is single-quoted, packed in `pprint`'s wrap style and lacks a trailing comma — output black immediately reformats, so isort + black never reach a fixpoint.

## Fix
Format the sorted literal to be black-compatible: double quotes, a single line when it fits `line_length`, otherwise one item per line (vertical-hanging-indent) with a trailing comma when `include_trailing_comma` is set, keeping the literal's own bracket type. It's a fixed black/PEP 8 layout — it deliberately does not reproduce every `multi_line_output` mode for literals (VHI is what black uses).

isort's output for a long `__all__` under `--profile=black`, before → after this fix:

```diff
-__all__ = ['Address', 'AliasAddress', 'BankAccountConnection', 'Certificate',
- 'ConcessionFee']
+__all__ = [
+    "Address",
+    "AliasAddress",
+    "BankAccountConnection",
+    "Certificate",
+    "ConcessionFee",
+]
```

Why drop pprint

pprint exposes only width; quote style, wrap mode and trailing comma are hardcoded to non-black output, so it could never satisfy `--profile=black`. It was the sole cause of the bug, so it's removed entirely — dict sorting now uses the same formatter and gets the same fix.

**Also fixes a `--check` crash on multi-line `__all__`**

Emitting multi-line `__all__` exposed a latent bug in the `--sort-reexports` rollback: it wrote the `__all__` opening line then did `output_stream.seek(output_stream.tell() - reexport_rollback)` to overwrite it with the sorted literal. In check mode the output is a no-op stream whose `tell()` is always `0`, so the seek went to a negative position and raised `ValueError: Negative seek position`. The seek target is now clamped to `0`; real seekable output is unaffected.

Note: sorted string literals are now double-quoted by default (isort has no quote setting); existing literal-sort test expectations are updated to match.