### PR TITLE
Fix typo in _preconvert docstring: JSONifyiable -> JSONifiable

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -888,7 +888,7 @@ def parse_args(argv: Sequence[str] | None = None) -> dict[str, Any]:
 
 
 def _preconvert(item: Any) -> str | list[Any]:
-    """Preconverts objects from native types into JSONifyiable types"""
+    """Preconverts objects from native types into JSONifiable types"""
     if isinstance(item, (set, frozenset)):
         return list(item)
     if isinstance(item, WrapModes):


### PR DESCRIPTION
## Summary

Fixes a small typo in the `_preconvert` function docstring in `isort/main.py`.

`JSONifyiable` has an extra `i` — the correct spelling is `JSONifiable`.

## Change

```
- """Preconverts objects from native types into JSONifyiable types"""
+ """Preconverts objects from native types into JSONifiable types"""
```

One-character fix, no behaviour change.