### PR TITLE
Document temporary .isorted files

### DIFF
--- a/docs/quick_start/2.-cli.md
+++ b/docs/quick_start/2.-cli.md
@@ -25,6 +25,20 @@ Finally, isort can just as easily be ran against individual source files. Simply
 
 <script id="asciicast-346602" src="https://asciinema.org/a/346602.js" async></script>
 
+## Temporary Files
+
+By default, when isort processes a source file, it writes the result to a
+sibling temporary file by appending `.isorted` to the source filename. If the
+content changes, this temporary file replaces the original. isort removes the
+temporary file when processing finishes and also attempts cleanup if sorting
+raises an exception.
+
+If the process terminates before cleanup runs, the temporary file may remain.
+It can be removed after isort has stopped. Projects where abrupt termination is
+possible can ignore `*.isorted` files, or use the
+[`--overwrite-in-place`](../configuration/options.md#overwrite-in-place)
+option to avoid creating them, with a performance and memory usage penalty.
+
 ## Multiple Projects
 
 Running a single isort command across multiple projects, or source files spanning multiple projects, is highly discouraged. Instead it is recommended that an isort process (or command) is ran for each project independently. This is because isort creates an immutable config for each CLI instance.


### PR DESCRIPTION
Closes #1943

## Summary

- explain when isort creates a sibling `.isorted` temporary file
- document normal and exception cleanup, plus possible residue after abrupt termination
- link to `--overwrite-in-place` as the no-temporary-file alternative and state its documented tradeoff

## Validation

- built all documentation with the repository's strict Sphinx flags (`--nitpicky --fail-on-warning --write-all --fresh-env`)
- skipped only the theme's Google Fonts download in an untracked local validation config after `fonts.google.com` timed out
- verified the rendered section and internal `--overwrite-in-place` link
- checked default cleanup, exception cleanup, and overwrite-in-place behavior against the current implementation
- `git diff --check`

## AI assistance

This documentation change was prepared with Codex assistance. I reviewed every statement against the current implementation, tightened the exception-cleanup wording after independent review, and ran the validation above.
