### PR TITLE
Honor skip comments when sorting reexports

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -253,7 +253,11 @@ def process(
                     code_sorting = stripped_line.split("isort: ")[1].strip()
                     code_sorting_indent = line[: -len(line.lstrip())]
                     not_imports = True
-                elif config.sort_reexports and stripped_line.startswith("__all__"):
+                elif (
+                    config.sort_reexports
+                    and stripped_line.startswith("__all__")
+                    and not _has_skip_comment(stripped_line)
+                ):
                     _, rhs = stripped_line.split("=")
                     code_sorting = LITERAL_TYPE_MAPPING.get(rhs.lstrip()[0], "tuple")
                     code_sorting_indent = line[: -len(line.lstrip())]

--- a/tests/unit/test_action_comments.py
+++ b/tests/unit/test_action_comments.py
@@ -46,3 +46,11 @@ import a
 import a
 """
     )
+
+
+def test_skip_sort_reexports():
+    code = """my_list = [\"bee\", \"Albatross\", \"Dinosaur\", \"cat\"]
+__all__ = my_list  # isort: skip
+"""
+
+    assert isort.code(code, sort_reexports=True) == code


### PR DESCRIPTION
Fixes #2569

## Summary
- Respect per-line `# isort: skip` comments when sorting `__all__` re-exports.
- Avoid attempting to parse skipped `__all__` assignments as literals.
- Add a regression test covering the reported behavior.

## Testing
- Reproduced the original failure with `isort --sort-reexports`.
- Verified the same reproduction succeeds and leaves the skipped line unchanged.
- `pytest -q` — 621 passed, 2 skipped
- `ruff check isort/core.py tests/unit/test_action_comments.py`
- `mypy isort/core.py tests/unit/test_action_comments.py`
- `flake8 isort/core.py tests/unit/test_action_comments.py`
- `isort --check-only isort/core.py tests/unit/test_action_comments.py`