### PR TITLE
bug: preserve trailing comma in --sort-reexports

### DIFF
--- a/isort/literal.py
+++ b/isort/literal.py
@@ -1,6 +1,6 @@
 import ast
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol
 
 from isort.exceptions import (
     AssignmentsFormatMismatch,
@@ -9,7 +9,19 @@ from isort.exceptions import (
 )
 from isort.settings import DEFAULT_CONFIG, Config
 
-type_mapping: dict[str, tuple[type, Callable[[Any, Config, int], str]]] = {}
+
+class _SortFunction(Protocol):
+    def __call__(
+        self,
+        value: Any,
+        config: Config,
+        prefix_length: int,
+        *,
+        force_multiline: bool = ...,
+    ) -> str: ...
+
+
+type_mapping: dict[str, tuple[type, _SortFunction]] = {}
 
 
 def assignments(code: str) -> str:
@@ -59,7 +71,8 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
 
     prefix_length = len(f"{variable_name} = ")
     force_multiline = had_trailing_comma and config.split_on_trailing_comma
-    sorted_value_code = f"{variable_name} = {sort_function(value, config, prefix_length, force_multiline=force_multiline)}"
+    sorted_value = sort_function(value, config, prefix_length, force_multiline=force_multiline)
+    sorted_value_code = f"{variable_name} = {sorted_value}"
     if config.formatting_function:
         sorted_value_code = config.formatting_function(
             sorted_value_code, extension, config
@@ -69,14 +82,12 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
     return sorted_value_code
 
 
-def register_type(
-    name: str, kind: type
-) -> Callable[[Callable[[Any, Config, int], str]], Callable[[Any, Config, int], str]]:
+def register_type(name: str, kind: type) -> Callable[[_SortFunction], _SortFunction]:
     """Registers a new literal sort type."""
 
     def wrap(
-        function: Callable[[Any, Config, int], str],
-    ) -> Callable[[Any, Config, int], str]:
+        function: _SortFunction,
+    ) -> _SortFunction:
         type_mapping[name] = (kind, function)
         return function
 
@@ -133,45 +144,103 @@ def _format_collection(
         return single_line
 
     indent = config.indent
-    trailing = "," if (force_multiline or config.include_trailing_comma or only_element_needs_comma) else ""
+    trailing = (
+        ","
+        if (force_multiline or config.include_trailing_comma or only_element_needs_comma)
+        else ""
+    )
     body = (",\n" + indent).join(elements)
     return f"{open_bracket}\n{indent}{body}{trailing}\n{close_bracket}"
 
 
 @register_type("dict", dict)
-def _dict(value: dict[Any, Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
+def _dict(
+    value: dict[Any, Any],
+    config: Config,
+    prefix_length: int,
+    force_multiline: bool = False,
+) -> str:
     items = [
         f"{_repr_element(key)}: {_repr_element(item)}"
         for key, item in sorted(value.items(), key=lambda item: item[1])
     ]
-    return _format_collection(items, "{", "}", config, prefix_length, force_multiline=force_multiline)
+    return _format_collection(
+        items, "{", "}", config, prefix_length, force_multiline=force_multiline
+    )
 
 
 @register_type("list", list)
-def _list(value: list[Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
+def _list(
+    value: list[Any],
+    config: Config,
+    prefix_length: int,
+    force_multiline: bool = False,
+) -> str:
     elements = [_repr_element(item) for item in sorted(value)]
-    return _format_collection(elements, "[", "]", config, prefix_length, force_multiline=force_multiline)
+    return _format_collection(
+        elements, "[", "]", config, prefix_length, force_multiline=force_multiline
+    )
 
 
 @register_type("unique-list", list)
-def _unique_list(value: list[Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
+def _unique_list(
+    value: list[Any],
+    config: Config,
+    prefix_length: int,
+    force_multiline: bool = False,
+) -> str:
     elements = [_repr_element(item) for item in sorted(set(value))]
-    return _format_collection(elements, "[", "]", config, prefix_length, force_multiline=force_multiline)
+    return _format_collection(
+        elements, "[", "]", config, prefix_length, force_multiline=force_multiline
+    )
 
 
 @register_type("set", set)
-def _set(value: set[Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
+def _set(
+    value: set[Any],
+    config: Config,
+    prefix_length: int,
+    force_multiline: bool = False,
+) -> str:
     elements = [_repr_element(item) for item in sorted(value)]
-    return _format_collection(elements, "{", "}", config, prefix_length, force_multiline=force_multiline)
+    return _format_collection(
+        elements, "{", "}", config, prefix_length, force_multiline=force_multiline
+    )
 
 
 @register_type("tuple", tuple)
-def _tuple(value: tuple[Any, ...], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
+def _tuple(
+    value: tuple[Any, ...],
+    config: Config,
+    prefix_length: int,
+    force_multiline: bool = False,
+) -> str:
     elements = [_repr_element(item) for item in sorted(value)]
-    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True, force_multiline=force_multiline)
+    return _format_collection(
+        elements,
+        "(",
+        ")",
+        config,
+        prefix_length,
+        single_element_comma=True,
+        force_multiline=force_multiline,
+    )
 
 
 @register_type("unique-tuple", tuple)
-def _unique_tuple(value: tuple[Any, ...], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
+def _unique_tuple(
+    value: tuple[Any, ...],
+    config: Config,
+    prefix_length: int,
+    force_multiline: bool = False,
+) -> str:
     elements = [_repr_element(item) for item in sorted(set(value))]
-    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True, force_multiline=force_multiline)
+    return _format_collection(
+        elements,
+        "(",
+        ")",
+        config,
+        prefix_length,
+        single_element_comma=True,
+        force_multiline=force_multiline,
+    )

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -140,7 +140,10 @@ def _format_collection(
     if only_element_needs_comma:
         inner += ","
     single_line = f"{open_bracket}{inner}{close_bracket}"
-    if not force_multiline and prefix_length + len(single_line) <= config.line_length:
+    # Single-element tuples need a trailing comma as syntax, not as a multiline
+    # signal, so allow them to collapse even when force_multiline is on.
+    fits_on_single_line = prefix_length + len(single_line) <= config.line_length
+    if (not force_multiline or only_element_needs_comma) and fits_on_single_line:
         return single_line
 
     indent = config.indent

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -42,6 +42,12 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
     variable_name, literal = code.split("=")
     variable_name = variable_name.strip()
     literal = literal.lstrip()
+    stripped_literal = literal.rstrip()
+    for close_bracket in (")", "]", "}"):
+        if stripped_literal.endswith(close_bracket):
+            stripped_literal = stripped_literal[:-1]
+            break
+    had_trailing_comma = stripped_literal.rstrip().endswith(",")
     try:
         value = ast.literal_eval(literal)
     except Exception as error:
@@ -52,7 +58,8 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
         raise LiteralSortTypeMismatch(type(value), expected_type)
 
     prefix_length = len(f"{variable_name} = ")
-    sorted_value_code = f"{variable_name} = {sort_function(value, config, prefix_length)}"
+    force_multiline = had_trailing_comma and config.split_on_trailing_comma
+    sorted_value_code = f"{variable_name} = {sort_function(value, config, prefix_length, force_multiline=force_multiline)}"
     if config.formatting_function:
         sorted_value_code = config.formatting_function(
             sorted_value_code, extension, config
@@ -107,61 +114,64 @@ def _format_collection(
     config: Config,
     prefix_length: int,
     single_element_comma: bool = False,
+    force_multiline: bool = False,
 ) -> str:
     """Render already-rendered, sorted ``elements`` as ``open ... close`` honoring the
     config: a single line when it fits within ``line_length`` (accounting for the
     ``prefix_length`` of the ``<name> = `` prefix), otherwise a vertical-hanging-indent
     block. ``single_element_comma`` forces the mandatory trailing comma that a
-    one-element tuple needs to stay a tuple.
+    one-element tuple needs to stay a tuple. ``force_multiline`` keeps the output on
+    multiple lines regardless of line length, used when the source carried a trailing
+    comma and ``split_on_trailing_comma`` is enabled.
     """
     only_element_needs_comma = single_element_comma and len(elements) == 1
     inner = ", ".join(elements)
     if only_element_needs_comma:
         inner += ","
     single_line = f"{open_bracket}{inner}{close_bracket}"
-    if prefix_length + len(single_line) <= config.line_length:
+    if not force_multiline and prefix_length + len(single_line) <= config.line_length:
         return single_line
 
     indent = config.indent
-    trailing = "," if (config.include_trailing_comma or only_element_needs_comma) else ""
+    trailing = "," if (force_multiline or config.include_trailing_comma or only_element_needs_comma) else ""
     body = (",\n" + indent).join(elements)
     return f"{open_bracket}\n{indent}{body}{trailing}\n{close_bracket}"
 
 
 @register_type("dict", dict)
-def _dict(value: dict[Any, Any], config: Config, prefix_length: int) -> str:
+def _dict(value: dict[Any, Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
     items = [
         f"{_repr_element(key)}: {_repr_element(item)}"
         for key, item in sorted(value.items(), key=lambda item: item[1])
     ]
-    return _format_collection(items, "{", "}", config, prefix_length)
+    return _format_collection(items, "{", "}", config, prefix_length, force_multiline=force_multiline)
 
 
 @register_type("list", list)
-def _list(value: list[Any], config: Config, prefix_length: int) -> str:
+def _list(value: list[Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
     elements = [_repr_element(item) for item in sorted(value)]
-    return _format_collection(elements, "[", "]", config, prefix_length)
+    return _format_collection(elements, "[", "]", config, prefix_length, force_multiline=force_multiline)
 
 
 @register_type("unique-list", list)
-def _unique_list(value: list[Any], config: Config, prefix_length: int) -> str:
+def _unique_list(value: list[Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
     elements = [_repr_element(item) for item in sorted(set(value))]
-    return _format_collection(elements, "[", "]", config, prefix_length)
+    return _format_collection(elements, "[", "]", config, prefix_length, force_multiline=force_multiline)
 
 
 @register_type("set", set)
-def _set(value: set[Any], config: Config, prefix_length: int) -> str:
+def _set(value: set[Any], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
     elements = [_repr_element(item) for item in sorted(value)]
-    return _format_collection(elements, "{", "}", config, prefix_length)
+    return _format_collection(elements, "{", "}", config, prefix_length, force_multiline=force_multiline)
 
 
 @register_type("tuple", tuple)
-def _tuple(value: tuple[Any, ...], config: Config, prefix_length: int) -> str:
+def _tuple(value: tuple[Any, ...], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
     elements = [_repr_element(item) for item in sorted(value)]
-    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True)
+    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True, force_multiline=force_multiline)
 
 
 @register_type("unique-tuple", tuple)
-def _unique_tuple(value: tuple[Any, ...], config: Config, prefix_length: int) -> str:
+def _unique_tuple(value: tuple[Any, ...], config: Config, prefix_length: int, force_multiline: bool = False) -> str:
     elements = [_repr_element(item) for item in sorted(set(value))]
-    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True)
+    return _format_collection(elements, "(", ")", config, prefix_length, single_element_comma=True, force_multiline=force_multiline)

--- a/tests/unit/test_literal.py
+++ b/tests/unit/test_literal.py
@@ -130,3 +130,40 @@ def test_value_assignment_unique_tuple():
         isort.literal.assignment("x = ('a', 'b', '1', '1')", "unique-tuple", "py")
         == 'x = ("1", "a", "b")'
     )
+
+
+def test_short_list_with_trailing_comma_force_multiline():
+    """A trailing comma forces multiline output when ``split_on_trailing_comma`` is on."""
+    assert (
+        isort.literal.assignment("x = ['b', 'a',]", "list", "py", config=Config(profile="black"))
+        == 'x = [\n    "a",\n    "b",\n]'
+    )
+
+
+def test_short_tuple_with_trailing_comma_force_multiline():
+    """Same force-multiline behaviour applies to tuples used for ``__all__``."""
+    assert (
+        isort.literal.assignment("x = ('b', 'a',)", "tuple", "py", config=Config(profile="black"))
+        == 'x = (\n    "a",\n    "b",\n)'
+    )
+
+
+def test_short_list_without_trailing_comma_stays_single_line():
+    """No trailing comma means the short collection may collapse to one line."""
+    assert (
+        isort.literal.assignment("x = ['b', 'a']", "list", "py", config=Config(profile="black"))
+        == 'x = ["a", "b"]'
+    )
+
+
+def test_trailing_comma_without_split_on_trailing_comma_stays_single_line():
+    """A trailing comma only forces multiline when ``split_on_trailing_comma`` is enabled."""
+    assert (
+        isort.literal.assignment(
+            "x = ['b', 'a',]",
+            "list",
+            "py",
+            config=Config(line_length=120, split_on_trailing_comma=False),
+        )
+        == 'x = ["a", "b"]'
+    )

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2217,6 +2217,26 @@ def test_sort_reexports_check_mode_multiline_all_issue_2280():
     assert isort.check_code(checked, show_diff=False, profile="black", sort_reexports=True)
 
 
+def test_sort_reexports_preserves_trailing_comma_issue_2578():
+    """``--sort-reexports`` must keep a trailing comma in a short ``__all__`` under the black profile.
+
+    A multi-line ``__all__`` with a trailing comma should not be collapsed to a single line,
+    because black treats a trailing comma as a request for one-item-per-line formatting.
+    See issue #2578: https://github.com/PyCQA/isort/issues/2578
+    """
+    test_input = '''__all__ = (
+    "SecondClass",
+    "FirstClass",
+)
+'''
+    expected_output = '''__all__ = (
+    "FirstClass",
+    "SecondClass",
+)
+'''
+    assert isort.code(test_input, profile="black", sort_reexports=True) == expected_output
+
+
 def test_noqa_added_to_long_force_single_line_as_import_with_comment_issue_2093():
     """A long ``as`` import with inline comment must get ``# NOQA`` in NOQA mode.
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2218,22 +2218,23 @@ def test_sort_reexports_check_mode_multiline_all_issue_2280():
 
 
 def test_sort_reexports_preserves_trailing_comma_issue_2578():
-    """``--sort-reexports`` must keep a trailing comma in a short ``__all__`` under the black profile.
+    """``--sort-reexports`` must keep a trailing comma in a short ``__all__``
+    under the black profile.
 
     A multi-line ``__all__`` with a trailing comma should not be collapsed to a single line,
     because black treats a trailing comma as a request for one-item-per-line formatting.
     See issue #2578: https://github.com/PyCQA/isort/issues/2578
     """
-    test_input = '''__all__ = (
+    test_input = """__all__ = (
     "SecondClass",
     "FirstClass",
 )
-'''
-    expected_output = '''__all__ = (
+"""
+    expected_output = """__all__ = (
     "FirstClass",
     "SecondClass",
 )
-'''
+"""
     assert isort.code(test_input, profile="black", sort_reexports=True) == expected_output
 
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2245,7 +2245,7 @@ def test_sort_reexports_single_element_tuple_stays_black_stable_issue_2578():
     multiline signal, so black leaves ``__all__ = ("a",)`` unchanged. isort
     should therefore produce the same output. See issue #2578.
     """
-    test_input = "__all__ = (\"a\",)\n"
+    test_input = '__all__ = ("a",)\n'
     assert isort.code(test_input, profile="black", sort_reexports=True) == test_input
 
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2238,6 +2238,17 @@ def test_sort_reexports_preserves_trailing_comma_issue_2578():
     assert isort.code(test_input, profile="black", sort_reexports=True) == expected_output
 
 
+def test_sort_reexports_single_element_tuple_stays_black_stable_issue_2578():
+    """``--sort-reexports`` must keep a single-element ``__all__`` on one line.
+
+    The trailing comma in ``("a",)`` is syntactically required, not a magic
+    multiline signal, so black leaves ``__all__ = ("a",)`` unchanged. isort
+    should therefore produce the same output. See issue #2578.
+    """
+    test_input = "__all__ = (\"a\",)\n"
+    assert isort.code(test_input, profile="black", sort_reexports=True) == test_input
+
+
 def test_noqa_added_to_long_force_single_line_as_import_with_comment_issue_2093():
     """A long ``as`` import with inline comment must get ``# NOQA`` in NOQA mode.
 


### PR DESCRIPTION
Fixes #2578

The `--sort-reexports` option added in 9.0.0b1 sorts `__all__` re-exports, but as reported in #2578 it collapses a short multiline `__all__` tuple to a single line even when the original ends with a trailing comma and `--profile black` is used:

```python
# before
__all__ = (
    "FirstClass",
    "SecondClass",
)

# after isort --sort-reexports --profile black
__all__ = ("FirstClass", "SecondClass")
```

That loses the one-per-line style the author intended, and it conflicts with black, which treats a trailing comma as a request to keep the collection expanded.

The root cause is in `isort/literal.py`: the formatter picks single-line versus vertical-hanging-indent output solely from `line_length`, so a collection that is short enough always collapses. This change makes `assignment()` detect whether the source literal ended with a trailing comma. When it did and `split_on_trailing_comma` is enabled (the default under the black profile), the sorted output is forced to stay multiline and keeps its trailing comma. The new `force_multiline` flag is threaded through the `_SortFunction` protocol so every registered collection type honors it.

One edge case is intentionally preserved: single-element tuples like `("a",)` keep their required syntactic comma and are not forced multiline, matching black's behavior.

I added regression tests in `tests/unit/test_literal.py` and `tests/unit/test_regressions.py` covering multiline lists/tuples, the no-trailing-comma case, and the single-element tuple case. The reproduction from #2578 now stays stable under `--sort-reexports --profile black`.
