### PR TITLE
Avoid leading newline with float-to-top

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -121,7 +121,10 @@ def process(
                         before = before[:-1]
                     extra_space = extra_space.replace("\n", "", 1)
                     sorted_output = output.sorted_imports(
-                        parsed, config, extension, import_type="import"
+                        parsed,
+                        Config(config=config, lines_before_imports=-1),
+                        extension,
+                        import_type="import",
                     )
                     made_changes = made_changes or _has_changed(
                         before=before,

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2387,3 +2387,12 @@ def test_isort_skip_is_honored_with_future_import_issue_2092():
     skip_index = next(i for i, line in enumerate(lines) if "# isort: skip" in line)
     assert lines.index("import ccc") > skip_index  # skip not relocated below the block
     assert isort.code(sorted_interleaved) == sorted_interleaved
+
+
+def test_lines_before_imports_with_float_to_top_issue_1935():
+    code = '"""Tmp module.\n"""\nimport os\nos.getcwd()\n'
+
+    assert (
+        isort.code(code, lines_before_imports=1, float_to_top=True)
+        == '"""Tmp module.\n"""\n\nimport os\n\nos.getcwd()\n'
+    )


### PR DESCRIPTION
Fixes #1935

## Summary
- Avoid applying `lines_before_imports` during the preliminary `float_to_top` pass.
- Let the normal sorting pass apply the configured spacing in the correct location.
- Add a regression test ensuring module docstrings remain at the beginning of the file.

## Testing
- Reproduced the original issue using `lines_before_imports = 1` and `float_to_top = true`.
- Verified that the module docstring remains on the first line after the fix.
- `pytest -q` — 621 passed, 2 skipped
- `pytest -q tests/unit/test_regressions.py -k "float_to_top or lines_before_imports"`
- `ruff check isort/core.py tests/unit/test_regressions.py`
- `mypy isort/core.py tests/unit/test_regressions.py`
- `flake8 isort/core.py tests/unit/test_regressions.py`
- `isort --check-only isort/core.py tests/unit/test_regressions.py`