### PR TITLE
Don't dynamically generate `WrapModes`

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -148,7 +148,7 @@ class _Config:
     known_standard_library: frozenset[str] = frozenset()
     extra_standard_library: frozenset[str] = frozenset()
     known_other: dict[str, frozenset[str]] = field(default_factory=dict)
-    multi_line_output: WrapModes = WrapModes.GRID  # type: ignore
+    multi_line_output: WrapModes = WrapModes.GRID
     forced_separate: tuple[str, ...] = ()
     indent: str = " " * 4
     comment_prefix: str = "  #"
@@ -253,8 +253,8 @@ class _Config:
                 self, "known_standard_library", frozenset(getattr(stdlibs, self.py_version).stdlib)
             )
 
-        if self.multi_line_output == WrapModes.VERTICAL_GRID_GROUPED_NO_COMMA:  # type: ignore
-            vertical_grid_grouped = WrapModes.VERTICAL_GRID_GROUPED  # type: ignore
+        if self.multi_line_output == WrapModes.VERTICAL_GRID_GROUPED_NO_COMMA:
+            vertical_grid_grouped = WrapModes.VERTICAL_GRID_GROUPED
             object.__setattr__(self, "multi_line_output", vertical_grid_grouped)
         if self.force_alphabetical_sort:
             object.__setattr__(self, "force_alphabetical_sort_within_sections", True)

--- a/isort/wrap.py
+++ b/isort/wrap.py
@@ -71,7 +71,7 @@ def import_statement(
 def line(content: str, line_separator: str, config: Config = DEFAULT_CONFIG) -> str:
     """Returns a line wrapped to the specified line-length, if possible."""
     wrap_mode = config.multi_line_output
-    if len(content) > config.line_length and wrap_mode != Modes.NOQA:  # type: ignore
+    if len(content) > config.line_length and wrap_mode != Modes.NOQA:
         line_without_comment = content
         comment = None
         if "#" in content:
@@ -83,8 +83,8 @@ def line(content: str, line_separator: str, config: Config = DEFAULT_CONFIG) -> 
             ):
                 line_parts = re.split(exp, line_without_comment)
                 _is_vertical_mode = wrap_mode in (
-                    Modes.VERTICAL_HANGING_INDENT,  # type: ignore
-                    Modes.VERTICAL_GRID_GROUPED,  # type: ignore
+                    Modes.VERTICAL_HANGING_INDENT,
+                    Modes.VERTICAL_GRID_GROUPED,
                 )
                 # Determine whether the comment should be hoisted to the opening
                 # parenthesis line rather than embedded in the import line.
@@ -149,7 +149,7 @@ def line(content: str, line_separator: str, config: Config = DEFAULT_CONFIG) -> 
                         output = line_separator.join(lines)
                     return output
                 return f"{content}{splitter}\\{line_separator}{cont_line}"
-    elif len(content) > config.line_length and wrap_mode == Modes.NOQA and "# NOQA" not in content:  # type: ignore
+    elif len(content) > config.line_length and wrap_mode == Modes.NOQA and "# NOQA" not in content:
         return f"{content}{config.comment_prefix} NOQA"
 
     return content

--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -2,7 +2,6 @@
 
 import enum
 from collections.abc import Callable
-from inspect import signature
 from typing import Any
 
 import isort.comments
@@ -35,12 +34,8 @@ def _wrap_mode_interface(
 
 
 def _wrap_mode(function: Callable[..., str]) -> Callable[..., str]:
-    """Registers an individual wrap mode. Function name and order are significant and used for
-    creating enum.
-    """
+    """Registers an individual wrap mode. Function name and order are significant."""
     _wrap_modes[function.__name__.upper()] = function
-    function.__signature__ = signature(_wrap_mode_interface)  # type: ignore
-    function.__annotations__ = _wrap_mode_interface.__annotations__
     return function
 
 
@@ -370,6 +365,16 @@ def backslash_grid(**interface: Any) -> str:
     return hanging_indent(**interface)
 
 
-WrapModes = enum.Enum(  # type: ignore
-    "WrapModes", {wrap_mode: index for index, wrap_mode in enumerate(_wrap_modes.keys())}
-)
+class WrapModes(enum.IntEnum):
+    GRID = 0
+    VERTICAL = 1
+    HANGING_INDENT = 2
+    VERTICAL_HANGING_INDENT = 3
+    VERTICAL_GRID = 4
+    VERTICAL_GRID_GROUPED = 5
+    VERTICAL_GRID_GROUPED_NO_COMMA = 6
+    NOQA = 7
+    VERTICAL_HANGING_INDENT_BRACKET = 8
+    VERTICAL_PREFIX_FROM_MODULE_IMPORT = 9
+    HANGING_INDENT_WITH_PARENTHESES = 10
+    BACKSLASH_GRID = 11

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -103,7 +103,7 @@ class TestConfig:
         )
 
     def test_deprecated_multi_line_output(self):
-        assert Config(multi_line_output=6).multi_line_output == WrapModes.VERTICAL_GRID_GROUPED  # type: ignore # noqa
+        assert Config(multi_line_output=6).multi_line_output == WrapModes.VERTICAL_GRID_GROUPED  # noqa
 
 
 def test_as_list():

--- a/tests/unit/test_wrap.py
+++ b/tests/unit/test_wrap.py
@@ -25,13 +25,13 @@ def test_import_statement():
     ("multi_line_output", "expected"),
     [
         (
-            WrapModes.VERTICAL_HANGING_INDENT,  # type: ignore
+            WrapModes.VERTICAL_HANGING_INDENT,
             """from a import (
     b as c  # comment that is long enough that this import doesn't fit in one line (parens)
 )""",
         ),
         (
-            WrapModes.VERTICAL,  # type: ignore
+            WrapModes.VERTICAL,
             """from a import (
     b as c)  # comment that is long enough that this import doesn't fit in one line (parens)""",
         ),

--- a/tests/unit/test_wrap_modes.py
+++ b/tests/unit/test_wrap_modes.py
@@ -4,6 +4,7 @@ from hypothesis import strategies as st
 
 import isort
 from isort import wrap_modes
+from isort.wrap_modes import WrapModes, _wrap_modes
 
 
 def test_wrap_mode_interface():
@@ -597,3 +598,13 @@ def test_fuzz_vertical_prefix_from_module_import(
         )
     except ValueError:
         reject()
+
+
+def test_enum_matches_order_of_definitions():
+    """Before isort 9.0.0 WrapModes was dynamically generated, this tests for breaking changes."""
+
+    old_enum_logic = {wrap_mode: index for index, wrap_mode in enumerate(_wrap_modes.keys())}
+    new_enum_logic = {wrap_mode.name: wrap_mode.value for wrap_mode in WrapModes}
+    assert old_enum_logic == new_enum_logic, (
+        "WrapModes enum order has changed, this is a breaking change."
+    )


### PR DESCRIPTION
Makes the codebase a little more type safe by not doing this dynamically.

It also is preparation for making wheels with `mypyc`.