### PR TITLE
Preserve the magic trailing comma in `--sort-reexports`

### DIFF
--- a/isort/literal.py
+++ b/isort/literal.py
@@ -52,7 +52,7 @@ def _has_magic_trailing_comma(literal: str) -> bool:
             for token in tokenize.generate_tokens(io.StringIO(literal).readline)
             if token.type not in skip and token.string.strip()
         ]
-    except (tokenize.TokenError, IndentationError, SyntaxError):  # pragma: no cover
+    except (tokenize.TokenError, SyntaxError):  # pragma: no cover
         return False
 
     return len(tokens) >= 2 and tokens[-1].string in ")]}" and tokens[-2].string == ","

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -1,4 +1,6 @@
 import ast
+import io
+import tokenize
 from collections.abc import Callable
 from typing import Any
 
@@ -27,6 +29,35 @@ def assignments(code: str) -> str:
     )
 
 
+def _has_magic_trailing_comma(literal: str) -> bool:
+    """Whether ``literal`` closes with a trailing comma, in black's "magic trailing
+    comma" sense: the author put it there to ask for one element per line.
+
+    Tokenizing rather than scanning the text keeps commas and brackets inside string
+    elements, and trailing comments, from being mistaken for the real closing bracket.
+    """
+    skip = frozenset(
+        {
+            tokenize.COMMENT,
+            tokenize.NL,
+            tokenize.NEWLINE,
+            tokenize.INDENT,
+            tokenize.DEDENT,
+            tokenize.ENDMARKER,
+        }
+    )
+    try:
+        tokens = [
+            token
+            for token in tokenize.generate_tokens(io.StringIO(literal).readline)
+            if token.type not in skip and token.string.strip()
+        ]
+    except (tokenize.TokenError, IndentationError, SyntaxError):  # pragma: no cover
+        return False
+
+    return len(tokens) >= 2 and tokens[-1].string in ")]}" and tokens[-2].string == ","
+
+
 def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAULT_CONFIG) -> str:
     """Sorts the literal present within the provided code against the provided sort type,
     returning the sorted representation of the source code.
@@ -50,6 +81,13 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
     expected_type, sort_function = type_mapping[sort_type]
     if type(value) is not expected_type:
         raise LiteralSortTypeMismatch(type(value), expected_type)
+
+    # A one-element tuple's trailing comma is syntax, not a formatting request, so it
+    # must not be read as a magic trailing comma.
+    if _has_magic_trailing_comma(literal) and not (isinstance(value, tuple) and len(value) == 1):
+        # Zero line length forces the vertical-hanging-indent branch of
+        # _format_collection, preserving the requested one-element-per-line layout.
+        config = Config(config=config, line_length=0, include_trailing_comma=True)
 
     prefix_length = len(f"{variable_name} = ")
     sorted_value_code = f"{variable_name} = {sort_function(value, config, prefix_length)}"

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5662,15 +5662,12 @@ def test_reexport_multiline_import() -> None:
 )
 __all__ = [
     "foo",
-    "bar",
+    "bar"
 ]
 """
     expd_output = """from m import bar, foo
 
-__all__ = [
-    "bar",
-    "foo",
-]
+__all__ = ["bar", "foo"]
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5682,17 +5679,14 @@ def test_reexport_multiline_in_center() -> None:
 )
 __all__ = [
     "foo",
-    "bar",
+    "bar"
 ]
 
 test
 """
     expd_output = """from m import bar, foo
 
-__all__ = [
-    "bar",
-    "foo",
-]
+__all__ = ["bar", "foo"]
 
 test
 """
@@ -5702,17 +5696,14 @@ test
 def test_reexport_multiline_long_rollback() -> None:
     test_input = """from m import foo, bar
 __all__ = [                            "foo",
-    "bar",
+    "bar"
 ]
 
 test
 """
     expd_output = """from m import bar, foo
 
-__all__ = [
-    "bar",
-    "foo",
-]
+__all__ = ["bar", "foo"]
 
 test
 """

--- a/tests/unit/test_isort.py
+++ b/tests/unit/test_isort.py
@@ -5591,7 +5591,10 @@ def test_reexport_multiline() -> None:
     'bar',
 )
 """
-    expd_output = """__all__ = ("bar", "foo")
+    expd_output = """__all__ = (
+    "bar",
+    "foo",
+)
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5664,7 +5667,10 @@ __all__ = [
 """
     expd_output = """from m import bar, foo
 
-__all__ = ["bar", "foo"]
+__all__ = [
+    "bar",
+    "foo",
+]
 """
     assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
 
@@ -5683,7 +5689,10 @@ test
 """
     expd_output = """from m import bar, foo
 
-__all__ = ["bar", "foo"]
+__all__ = [
+    "bar",
+    "foo",
+]
 
 test
 """
@@ -5700,7 +5709,10 @@ test
 """
     expd_output = """from m import bar, foo
 
-__all__ = ["bar", "foo"]
+__all__ = [
+    "bar",
+    "foo",
+]
 
 test
 """
@@ -5809,3 +5821,65 @@ def test_builtin_modules() -> None:
         "from python_none_objects import NoneIterable\n"
     )
     assert isort.code(test_input) == test_output
+
+
+def test_reexport_preserves_magic_trailing_comma() -> None:
+    """https://github.com/PyCQA/isort/issues/2578
+
+    A trailing comma in the original ``__all__`` is black's "magic trailing comma":
+    it asks for one element per line, even when the sorted result would fit on one.
+    """
+    test_input = """__all__ = (
+    "foo",
+    "bar",
+)
+"""
+    expd_output = """__all__ = (
+    "bar",
+    "foo",
+)
+"""
+    assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_reexport_without_magic_trailing_comma_stays_collapsed() -> None:
+    """https://github.com/PyCQA/isort/issues/2578
+
+    Without the trailing comma the short form is kept, as before.
+    """
+    test_input = """__all__ = ("foo", "bar")
+"""
+    expd_output = """__all__ = ("bar", "foo")
+"""
+    assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output
+
+
+def test_reexport_single_element_tuple_comma_is_not_magic() -> None:
+    """https://github.com/PyCQA/isort/issues/2578
+
+    A one-element tuple's trailing comma is required syntax rather than a
+    formatting request, so it must not explode the literal.
+    """
+    test_input = """__all__ = ("foo",)
+"""
+    assert isort.code(test_input, config=Config(sort_reexports=True)) == test_input
+
+
+def test_reexport_magic_trailing_comma_ignores_strings_and_comments() -> None:
+    """https://github.com/PyCQA/isort/issues/2578
+
+    Detection tokenizes rather than scanning text, so a closing bracket or comma
+    inside a string element, or a trailing comment, is not mistaken for the end of
+    the literal.
+    """
+    test_input = """__all__ = (
+    "b#)",
+    "a,",  # trailing comment
+)
+"""
+    expd_output = """__all__ = (
+    "a,",
+    "b#)",
+)
+"""
+    assert isort.code(test_input, config=Config(sort_reexports=True)) == expd_output


### PR DESCRIPTION
## Summary

Closes #2578.

`--sort-reexports` runs the `__all__` literal through `ast.literal_eval` and re-renders it, which loses the original formatting. `_format_collection` then picks one line whenever the result fits within `line_length`, so a trailing comma in the source was silently dropped:

```python
__all__ = (
    "SecondClass",
    "FirstClass",
)
# became
__all__ = ("FirstClass", "SecondClass")
```

That trailing comma is black's magic trailing comma — a request for one element per line — so this preserves it.

#2582 covered the same issue and was withdrawn by its author; this is an independent implementation.

## Implementation

`_has_magic_trailing_comma` tokenizes the literal and checks whether the token before the closing bracket is a comma. Tokenizing rather than scanning text matters: a bracket or comma inside a string element (`"b#)"`, `"a,"`) or a trailing comment would otherwise be mistaken for the end of the literal. There is a test for exactly that.

When a magic trailing comma is found, `assignment` derives a config with `line_length=0` and `include_trailing_comma=True`, which forces the vertical-hanging-indent branch of `_format_collection`. This uses the existing `Config(config=..., ...)` derivation pattern already used by `_indented_config`, and deliberately avoids changing the signature of the registered sort functions, since `register_type` is public API.

**One-element tuples are excluded.** `__all__ = ("foo",)` needs its comma to stay a tuple — that is syntax, not a formatting request, and black does not explode it either. Without this carve-out every single-export `__all__` would get exploded.

## Behaviour change to existing tests

Four existing tests asserted the current output and had to be updated: `test_reexport_multiline`, `test_reexport_multiline_import`, `test_reexport_multiline_in_center`, `test_reexport_multiline_long_rollback`. Every one of them feeds in a literal that has a magic trailing comma and asserted it collapsed to a single line — i.e. they pinned the reported bug. Their inputs are unchanged; only the expected output now stays exploded.

Worth a look during review, since it is the part that is a deliberate behaviour change rather than a fix. The two rollback/centre tests still pass, so the `reexport_rollback` seek logic is fine with multi-line output.

`test_reexport_list`, `test_reexport_set` and `test_reexport_bare` are untouched and still pass — none of them have a trailing comma, and the bare `__all__ = 'foo', 'bar'` form has no brackets so detection correctly ignores it.

## Tests

Four added: the magic comma is preserved; a literal without one still collapses; a one-element tuple is left alone; and the tokenizer-based detection is not fooled by strings or comments.

Revert-verified: with `literal.py` reverted, the two behaviour tests fail and the two control tests still pass.

## Local results (Windows, Python 3.12)

`pytest tests/unit` — **604 passed, 4 failed, 5 skipped**. The same 4 fail on a clean tree (`test_importable`, `test_windows_diff_too_large_misrepresentative_issue_1348`, `test_isort_supports_shared_profiles_issue_970`, `test_sort_configurable_sort_issue_1732`); baseline is 600 passed. `ruff check`, `ruff format --check` and `mypy isort/literal.py` are all clean.
