### PR TITLE
fix: don't crash on --config-root without --resolve-all-configs

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1038,13 +1038,14 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
     ext_format = config_dict.pop("ext_format", None)
     allow_root = config_dict.pop("allow_root", None)
     resolve_all_configs = config_dict.pop("resolve_all_configs", False)
+    config_root = config_dict.pop("config_root", ".")
     wrong_sorted_files = False
     all_attempt_broken = False
     no_valid_encodings = False
 
     config_trie: Trie | None = None
     if resolve_all_configs:
-        config_trie = find_all_configs(config_dict.pop("config_root", "."))
+        config_trie = find_all_configs(config_root)
 
     if "src_paths" in config_dict:
         # Keep CLI-provided values as-is so wildcard patterns can be expanded later

--- a/isort/main.py
+++ b/isort/main.py
@@ -1038,7 +1038,10 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
     ext_format = config_dict.pop("ext_format", None)
     allow_root = config_dict.pop("allow_root", None)
     resolve_all_configs = config_dict.pop("resolve_all_configs", False)
+    config_root_given = "config_root" in config_dict
     config_root = config_dict.pop("config_root", ".")
+    if config_root_given and not resolve_all_configs:
+        sys.exit("Error: --config-root (--cr) has no effect without --resolve-all-configs.")
     wrong_sorted_files = False
     all_attempt_broken = False
     no_valid_encodings = False

--- a/isort/main.py
+++ b/isort/main.py
@@ -1038,9 +1038,7 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
     ext_format = config_dict.pop("ext_format", None)
     allow_root = config_dict.pop("allow_root", None)
     resolve_all_configs = config_dict.pop("resolve_all_configs", False)
-    config_root_given = "config_root" in config_dict
-    config_root = config_dict.pop("config_root", ".")
-    if config_root_given and not resolve_all_configs:
+    if "config_root" in config_dict and not resolve_all_configs:
         sys.exit("Error: --config-root (--cr) has no effect without --resolve-all-configs.")
     wrong_sorted_files = False
     all_attempt_broken = False
@@ -1048,7 +1046,7 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
 
     config_trie: Trie | None = None
     if resolve_all_configs:
-        config_trie = find_all_configs(config_root)
+        config_trie = find_all_configs(config_dict.pop("config_root", "."))
 
     if "src_paths" in config_dict:
         # Keep CLI-provided values as-is so wildcard patterns can be expanded later

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -158,6 +158,16 @@ def test_ran_against_root():
         main.main(["/"])
 
 
+def test_config_root_without_resolve_all_configs(tmpdir):
+    # --config-root should be usable on its own (it's only consulted when
+    # --resolve-all-configs is also given) instead of blowing up with
+    # UnsupportedSettings. See #1990.
+    python_file = tmpdir.join("file.py")
+    python_file.write("import os\n")
+
+    main.main([str(python_file), "--config-root", str(tmpdir)])
+
+
 def test_main(capsys, tmpdir):
     base_args = [
         "--sp",

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -159,13 +159,24 @@ def test_ran_against_root():
 
 
 def test_config_root_without_resolve_all_configs(tmpdir):
-    # --config-root should be usable on its own (it's only consulted when
-    # --resolve-all-configs is also given) instead of blowing up with
-    # UnsupportedSettings. See #1990.
+    # --config-root only means anything alongside --resolve-all-configs. Used to
+    # blow up with a confusing UnsupportedSettings/config_dict crash (#1990), now
+    # it exits with a clear error instead.
     python_file = tmpdir.join("file.py")
     python_file.write("import os\n")
 
-    main.main([str(python_file), "--config-root", str(tmpdir)])
+    with pytest.raises(SystemExit) as exc_info:
+        main.main([str(python_file), "--config-root", str(tmpdir)])
+    assert "--resolve-all-configs" in str(exc_info.value)
+
+
+def test_config_root_with_resolve_all_configs(tmpdir):
+    python_file = tmpdir.join("file.py")
+    python_file.write("import os\n")
+
+    main.main(
+        [str(python_file), "--config-root", str(tmpdir), "--resolve-all-configs"]
+    )
 
 
 def test_main(capsys, tmpdir):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -158,10 +158,7 @@ def test_ran_against_root():
         main.main(["/"])
 
 
-def test_config_root_without_resolve_all_configs(tmpdir):
-    # --config-root only means anything alongside --resolve-all-configs. Used to
-    # blow up with a confusing UnsupportedSettings/config_dict crash (#1990), now
-    # it exits with a clear error instead.
+def test_config_root_interaction_with_resolve_all_configs(tmpdir):
     python_file = tmpdir.join("file.py")
     python_file.write("import os\n")
 
@@ -169,14 +166,7 @@ def test_config_root_without_resolve_all_configs(tmpdir):
         main.main([str(python_file), "--config-root", str(tmpdir)])
     assert "--resolve-all-configs" in str(exc_info.value)
 
-
-def test_config_root_with_resolve_all_configs(tmpdir):
-    python_file = tmpdir.join("file.py")
-    python_file.write("import os\n")
-
-    main.main(
-        [str(python_file), "--config-root", str(tmpdir), "--resolve-all-configs"]
-    )
+    main.main([str(python_file), "--config-root", str(tmpdir), "--resolve-all-configs"])
 
 
 def test_main(capsys, tmpdir):


### PR DESCRIPTION
yeah this one's just been broken since forever. `--config-root` on its own throws a raw `UnsupportedSettings` traceback instead of doing... anything.

Root cause is in `main.py`: `config_root` only gets popped out of `config_dict` inside the `if resolve_all_configs:` branch. So if you pass `--config-root` without also passing `--resolve-all-configs`, it's still sitting in the dict when it gets splatted into `Config(**config_dict)`, and `Config` has no idea what `config_root` is, so it errors out.

The help text for the flag literally says it's "used with the --resolve-all-configs flag" - so without that flag it should just be a no-op, not a crash. Fix is to pop it unconditionally, same as `resolve_all_configs` itself already is a few lines up.

Verified against main: reverted my change locally and reproduced the exact traceback from #1990 (`isort.exceptions.UnsupportedSettings: ... - config_root = ..`). With the fix it runs fine.

Added a regression test in `tests/unit/test_main.py` that calls `--config-root` without `--resolve-all-configs` and just checks it doesn't blow up.

Fixes #1990
