### PR TITLE
Add `--force-separate-as-imports` option to keep non-aliased imports grouped together

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -434,6 +434,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Combines as imports on the same line.",
     )
     output_group.add_argument(
+        "--fsai",
+        "--force-separate-as-imports",
+        dest="force_separate_as_imports",
+        action="store_true",
+        help="Forces as imports to be emitted after the plain imports of the same "
+        "module, keeping the plain imports grouped in a single statement. "
+        "Has no effect when combine-as is enabled.",
+    )
+    output_group.add_argument(
         "--cs",
         "--combine-star",
         dest="combine_star",

--- a/isort/output.py
+++ b/isort/output.py
@@ -337,9 +337,10 @@ def _with_from_imports(
             for from_import, sub_module in zip(from_imports, sub_modules, strict=False)
             if sub_module in parsed.as_map["from"]
         }
-        # when not combine_as_imports, move aliased imports to the end so that
-        # non-aliased imports stay grouped together in a single block
-        if not config.combine_as_imports and as_imports:
+        # when force_separate_as_imports (and not combine_as_imports), move aliased
+        # imports to the end so that non-aliased imports stay grouped together in a
+        # single block
+        if config.force_separate_as_imports and not config.combine_as_imports and as_imports:
             non_aliased = [imp for imp in from_imports if imp not in as_imports]
             aliased = [imp for imp in from_imports if imp in as_imports]
             from_imports = non_aliased + aliased

--- a/isort/output.py
+++ b/isort/output.py
@@ -337,6 +337,12 @@ def _with_from_imports(
             for from_import, sub_module in zip(from_imports, sub_modules, strict=False)
             if sub_module in parsed.as_map["from"]
         }
+        # when not combine_as_imports, move aliased imports to the end so that
+        # non-aliased imports stay grouped together in a single block
+        if not config.combine_as_imports and as_imports:
+            non_aliased = [imp for imp in from_imports if imp not in as_imports]
+            aliased = [imp for imp in from_imports if imp in as_imports]
+            from_imports = non_aliased + aliased
         if config.combine_as_imports and not ("*" in from_imports and config.combine_star):
             if not config.no_inline_sort:
                 for as_import in as_imports:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -173,6 +173,7 @@ class _Config:
     lines_between_sections: int = 1
     lines_between_types: int = 0
     combine_as_imports: bool = False
+    force_separate_as_imports: bool = False
     combine_star: bool = False
     include_trailing_comma: bool = False
     from_first: bool = False


### PR DESCRIPTION
Introduces `--force-separate-as-imports`, which separates the non-aliased import group from the aliased import group.

This is a proposed minimal change for #2455. The design for this issue is not decided yet, so this PR is a demo and does not include documentation or test updates. Once the design is accepted, I will work on those too.

File1.py:

```python
from module import (
    AAAAAAAAAAAAAAAAAAAAAAAAAA,
    BBBBBBBBBBBBBBBBBBBBBBBBBB,
    CCCCCCCCCCCCCCCCCCCCCCCCCC,
)
from module import DDDDDDDDDDDDDDDDDDDDDDDDDD as d
from module import (
    EEEEEEEEEEEEEEEEEEEEEEEEEE,
    FFFFFFFFFFFFFFFFFFFFFFFFFF,
    GGGGGGGGGGGGGGGGGGGGGGGGGG,
)
```

Without the option (which behaves the same as main, no breaking changes)

```bash
$ isort file1.py -d --fss
from module import (AAAAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBBBBBB,
                    CCCCCCCCCCCCCCCCCCCCCCCCCC)
from module import (EEEEEEEEEEEEEEEEEEEEEEEEEE, FFFFFFFFFFFFFFFFFFFFFFFFFF,
                    GGGGGGGGGGGGGGGGGGGGGGGGGG)
from module import DDDDDDDDDDDDDDDDDDDDDDDDDD as d
```

With the option:

```bash
$ isort file1.py -d --fss --fsai
from module import (AAAAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBBBBBB,
                    CCCCCCCCCCCCCCCCCCCCCCCCCC, EEEEEEEEEEEEEEEEEEEEEEEEEE,
                    FFFFFFFFFFFFFFFFFFFFFFFFFF, GGGGGGGGGGGGGGGGGGGGGGGGGG)
from module import DDDDDDDDDDDDDDDDDDDDDDDDDD as d
```
