### PR TITLE
Fix preservation of form-feed blank lines

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -132,10 +132,11 @@ def sorted_imports(
 
     if output:
         imports_tail = output_at + len(output)
+        trailing_blank_lines: list[str] = []
         while [
             character.strip() for character in formatted_output[imports_tail : imports_tail + 1]
         ] == [""]:
-            formatted_output.pop(imports_tail)
+            trailing_blank_lines.append(formatted_output.pop(imports_tail))
 
         if config.lines_before_imports != -1:
             lines_before_imports = config.lines_before_imports
@@ -169,11 +170,24 @@ def sorted_imports(
                 lines_after_imports = config.lines_after_imports
                 if config.profile == "black" and extension == "pyi":  # special case for black
                     lines_after_imports = 1
-                formatted_output[imports_tail:0] = ["" for line in range(lines_after_imports)]
             elif extension != "pyi" and next_construct.startswith(STATEMENT_DECLARATIONS):
-                formatted_output[imports_tail:0] = ["", ""]
+                lines_after_imports = 2
             else:
-                formatted_output[imports_tail:0] = [""]
+                lines_after_imports = 1
+
+            blank_lines = [""] * lines_after_imports
+            overflow_form_feeds = ""
+            for index, line in enumerate(trailing_blank_lines):
+                form_feeds = "".join(character for character in line if character == "\f")
+                if index < lines_after_imports:
+                    blank_lines[index] += form_feeds
+                else:
+                    overflow_form_feeds += form_feeds
+            if overflow_form_feeds:
+                formatted_output[imports_tail] = (
+                    overflow_form_feeds + formatted_output[imports_tail]
+                )
+            formatted_output[imports_tail:0] = blank_lines
 
     if parsed.place_imports:
         new_out_lines = []

--- a/isort/parse.py
+++ b/isort/parse.py
@@ -77,9 +77,13 @@ class ParsedContent(NamedTuple):
 def file_contents(contents: str, config: Config = DEFAULT_CONFIG) -> ParsedContent:
     """Parses a python file taking out and categorizing imports."""
     line_separator: str = config.line_ending or _infer_line_separator(contents)
-    in_lines = contents.splitlines()
-    if contents and contents[-1] in ("\n", "\r"):
-        in_lines.append("")
+    # ``str.splitlines`` also treats characters such as form feed as line
+    # boundaries, even though Python's universal-newline handling does not.
+    # Normalize actual newline sequences explicitly so those characters stay
+    # attached to their source line.
+    in_lines = contents.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    if not contents:
+        in_lines = []
 
     out_lines = []
     original_line_count = len(in_lines)

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -48,6 +48,19 @@ def test_file_contents():
     assert original_line_count == len(in_lines)
 
 
+def test_file_contents_empty():
+    parsed = parse.file_contents("", config=Config(default_section=""))
+    assert parsed.in_lines == []
+    assert parsed.original_line_count == 0
+
+
+@pytest.mark.parametrize("line_separator", ["\n", "\r\n", "\r"])
+def test_file_contents_splits_only_on_newlines(line_separator):
+    contents = line_separator.join(["import b", "import a", "\fpass"])
+    parsed = parse.file_contents(contents, config=Config(default_section=""))
+    assert parsed.in_lines == ["import b", "import a", "\fpass"]
+
+
 # These tests were written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -181,6 +181,17 @@ class Something(object):
     assert isort.code(test_input, lines_after_imports=2) == test_input
 
 
+def test_form_feed_blank_line_not_removed_issue_2562():
+    """Ensure isort preserves form feed as a valid blank line."""
+    test_input = 'import sys\n\n\f\nprint("!")\n'
+    assert isort.code(test_input) == 'import sys\n\n\fprint("!")\n'
+    assert isort.code(test_input, lines_after_imports=2) == test_input
+
+    test_input = 'import sys\n\n\n\fprint("!")\n'
+    assert isort.code(test_input) == 'import sys\n\n\fprint("!")\n'
+    assert isort.code(test_input, lines_after_imports=2) == test_input
+
+
 def test_force_single_line_shouldnt_remove_preceding_comment_lines_issue_1296():
     """Tests to ensure force_single_line setting doesn't result in lost comments.
     See: https://github.com/pycqa/isort/issues/1296


### PR DESCRIPTION
## Summary

- split source text only on actual newline sequences so form feeds remain part of their source line
- preserve form feeds while normalizing the configured number of blank lines after imports
- add the maintainer-proposed regression cases for both default and explicit `lines_after_imports`

Closes #2562.

## Tests

- `python -m pytest tests/unit/test_parse.py tests/unit/test_regressions.py -q` (113 passed)
- `python -m pytest tests/unit --ignore=tests/unit/test_importable.py -q` (607 passed, 5 skipped; the excluded smoke test is an unrelated baseline failure on current main)
- `ruff check isort/parse.py isort/output.py tests/unit/test_regressions.py --ignore PLC0207`
- `python -m compileall -q isort`
- `git diff --check`