### PR TITLE
Remove `_EmptyIO`

### DIFF
--- a/isort/api.py
+++ b/isort/api.py
@@ -15,6 +15,7 @@ __all__ = (
 )
 
 import contextlib
+import os
 import shutil
 import sys
 from collections.abc import Iterator
@@ -37,7 +38,7 @@ from .exceptions import (
     IntroducedSyntaxErrors,
 )
 from .format import ask_whether_to_apply_changes_to_file, create_terminal_printer, show_unified_diff
-from .io import Empty, File
+from .io import File
 from .place import module as place_module  # noqa: F401
 from .place import module_with_reason as place_module_with_reason  # noqa: F401
 from .settings import CYTHON_EXTENSIONS, DEFAULT_CONFIG, Config
@@ -259,14 +260,15 @@ def check_stream(
     if show_diff:
         input_stream = StringIO(input_stream.read())
 
-    changed: bool = sort_stream(
-        input_stream=input_stream,
-        output_stream=Empty,
-        extension=extension,
-        config=config,
-        file_path=file_path,
-        disregard_skip=disregard_skip,
-    )
+    with open(os.devnull, "w") as devnull:
+        changed: bool = sort_stream(
+            input_stream=input_stream,
+            output_stream=devnull,
+            extension=extension,
+            config=config,
+            file_path=file_path,
+            disregard_skip=disregard_skip,
+        )
     printer = create_terminal_printer(
         color=config.color_output, error=config.format_error, success=config.format_success
     )

--- a/isort/core.py
+++ b/isort/core.py
@@ -172,7 +172,12 @@ def process(
                     ignore_whitespace=config.ignore_whitespace,
                 )
                 output_stream.write(sorted_code)
-                if is_reexport:
+                if (
+                    is_reexport
+                    # Check if we need to truncate. If we're redirecting to `devnull` we don't need
+                    # to and don't want to call `truncate()` on it, as it will raise an exception.
+                    and output_stream.tell() > 0
+                ):
                     output_stream.truncate()
         else:
             stripped_line = line.strip()
@@ -288,7 +293,13 @@ def process(
                             output_stream.seek(max(0, output_stream.tell() - reexport_rollback))
                             reexport_rollback = 0
                         output_stream.write(sorted_code)
-                        if is_reexport:
+                        if (
+                            is_reexport
+                            # Check if we need to truncate. If we're redirecting to `devnull` we
+                            # don't need to and don't want to call `truncate()` on it, as it will
+                            # raise an exception.
+                            and output_stream.tell() > 0
+                        ):
                             output_stream.truncate()
                         not_imports = True
                         code_sorting = False

--- a/isort/io.py
+++ b/isort/io.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
-from typing import Any, TextIO
+from typing import TextIO
 
 from isort.exceptions import UnsupportedEncoding
 
@@ -60,11 +60,3 @@ class File:
         finally:
             if stream is not None:
                 stream.close()
-
-
-class _EmptyIO(StringIO):
-    def write(self, *args: Any, **kwargs: Any) -> None:  # type: ignore # skipcq: PTC-W0049
-        pass
-
-
-Empty = _EmptyIO()


### PR DESCRIPTION
Let's try https://github.com/PyCQA/isort/pull/2593 again, this time with a guard around `.truncate()`