### PR TITLE
Preserve LF stdin output on Windows

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -13,7 +13,6 @@ from dataclasses import asdict
 from gettext import gettext as _
 from io import TextIOWrapper
 from pathlib import Path
-from types import TracebackType
 from typing import Any, TextIO, cast
 from warnings import warn
 
@@ -55,45 +54,24 @@ class SortAttempt:
         return (self.__class__, (self.incorrectly_sorted, self.skipped, self.supported_encoding))
 
 
-class _StreamWithPreservedNewlines(AbstractContextManager[TextIO]):
-    def __init__(self, stream: TextIO, mode: str) -> None:
-        self.stream = stream
-        self.mode = mode
-        self.wrapped_stream: TextIO | None = None
-
-    def __enter__(self) -> TextIO:
-        if not isinstance(self.stream, TextIOWrapper):
-            return self.stream
-
-        try:
-            self.wrapped_stream = cast(
-                TextIO,
-                open(
-                    self.stream.fileno(),
-                    self.mode,
-                    encoding=self.stream.encoding,
-                    errors=self.stream.errors,
-                    newline="",
-                    closefd=False,
-                ),
-            )
-        except OSError:
-            return self.stream
-
-        return self.wrapped_stream
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        if self.wrapped_stream is not None:
-            self.wrapped_stream.close()
-
-
 def _stream_with_preserved_newlines(stream: TextIO, mode: str) -> AbstractContextManager[TextIO]:
-    return _StreamWithPreservedNewlines(stream, mode)
+    if not isinstance(stream, TextIOWrapper):
+        return nullcontext(stream)
+
+    try:
+        return cast(
+            AbstractContextManager[TextIO],
+            open(
+                stream.fileno(),
+                mode,
+                encoding=stream.encoding,
+                errors=stream.errors,
+                newline="",
+                closefd=False,
+            ),
+        )
+    except OSError:
+        return nullcontext(stream)
 
 
 def sort_imports(

--- a/isort/main.py
+++ b/isort/main.py
@@ -8,12 +8,12 @@ import json
 import os
 import sys
 from collections.abc import Iterator, Sequence
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from dataclasses import asdict
 from gettext import gettext as _
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 from warnings import warn
 
 from . import api, files, sections
@@ -52,6 +52,31 @@ class SortAttempt:
         # Defined explicitly as mypyc's removal of `__dict__` breaks pickling this class, which is
         # necessary when using multiple jobs.
         return (self.__class__, (self.incorrectly_sorted, self.skipped, self.supported_encoding))
+
+
+@contextmanager
+def _stream_with_preserved_newlines(stream: TextIO, mode: str) -> Iterator[TextIO]:
+    if not isinstance(stream, TextIOWrapper):
+        yield stream
+        return
+
+    try:
+        wrapped_stream = open(
+            stream.fileno(),
+            mode,
+            encoding=stream.encoding,
+            errors=stream.errors,
+            newline="",
+            closefd=False,
+        )
+    except OSError:
+        yield stream
+        return
+
+    try:
+        yield wrapped_stream
+    finally:
+        wrapped_stream.close()
 
 
 def sort_imports(
@@ -1073,30 +1098,33 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
         if config.sort_reexports:
             sys.exit("Error: --sort-reexports is not supported with streaming input (stdin).")
 
-        input_stream = sys.stdin if stdin is None else stdin
-        if check:
-            incorrectly_sorted = not api.check_stream(
-                input_stream=input_stream,
-                config=config,
-                show_diff=show_diff,
-                file_path=file_path,
-                extension=ext_format,
-            )
-
-            wrong_sorted_files = incorrectly_sorted
-        else:
-            try:
-                api.sort_stream(
+        raw_input_stream = sys.stdin if stdin is None else stdin
+        with _stream_with_preserved_newlines(raw_input_stream, "r") as input_stream:
+            if check:
+                incorrectly_sorted = not api.check_stream(
                     input_stream=input_stream,
-                    output_stream=sys.stdout,
                     config=config,
                     show_diff=show_diff,
                     file_path=file_path,
                     extension=ext_format,
-                    raise_on_skip=False,
                 )
-            except FileSkipped:
-                sys.stdout.write(input_stream.read())
+
+                wrong_sorted_files = incorrectly_sorted
+            else:
+                try:
+                    with _stream_with_preserved_newlines(sys.stdout, "w") as output_stream:
+                        api.sort_stream(
+                            input_stream=input_stream,
+                            output_stream=output_stream,
+                            config=config,
+                            show_diff=show_diff,
+                            file_path=file_path,
+                            extension=ext_format,
+                            raise_on_skip=False,
+                        )
+                except FileSkipped:
+                    with _stream_with_preserved_newlines(sys.stdout, "w") as output_stream:
+                        output_stream.write(input_stream.read())
     elif "/" in file_names and not allow_root:
         printer = create_terminal_printer(
             color=config.color_output, error=config.format_error, success=config.format_success

--- a/isort/main.py
+++ b/isort/main.py
@@ -13,7 +13,7 @@ from dataclasses import asdict
 from gettext import gettext as _
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any, TextIO, cast
 from warnings import warn
 
 from . import api, files, sections
@@ -74,7 +74,7 @@ def _stream_with_preserved_newlines(stream: TextIO, mode: str) -> Iterator[TextI
         return
 
     try:
-        yield wrapped_stream
+        yield cast(TextIO, wrapped_stream)
     finally:
         wrapped_stream.close()
 

--- a/isort/main.py
+++ b/isort/main.py
@@ -8,11 +8,12 @@ import json
 import os
 import sys
 from collections.abc import Iterator, Sequence
-from contextlib import AbstractContextManager, contextmanager, nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict
 from gettext import gettext as _
 from io import TextIOWrapper
 from pathlib import Path
+from types import TracebackType
 from typing import Any, TextIO, cast
 from warnings import warn
 
@@ -54,29 +55,45 @@ class SortAttempt:
         return (self.__class__, (self.incorrectly_sorted, self.skipped, self.supported_encoding))
 
 
-@contextmanager
-def _stream_with_preserved_newlines(stream: TextIO, mode: str) -> Iterator[TextIO]:
-    if not isinstance(stream, TextIOWrapper):
-        yield stream
-        return
+class _StreamWithPreservedNewlines(AbstractContextManager[TextIO]):
+    def __init__(self, stream: TextIO, mode: str) -> None:
+        self.stream = stream
+        self.mode = mode
+        self.wrapped_stream: TextIO | None = None
 
-    try:
-        wrapped_stream = open(
-            stream.fileno(),
-            mode,
-            encoding=stream.encoding,
-            errors=stream.errors,
-            newline="",
-            closefd=False,
-        )
-    except OSError:
-        yield stream
-        return
+    def __enter__(self) -> TextIO:
+        if not isinstance(self.stream, TextIOWrapper):
+            return self.stream
 
-    try:
-        yield cast(TextIO, wrapped_stream)
-    finally:
-        wrapped_stream.close()
+        try:
+            self.wrapped_stream = cast(
+                TextIO,
+                open(
+                    self.stream.fileno(),
+                    self.mode,
+                    encoding=self.stream.encoding,
+                    errors=self.stream.errors,
+                    newline="",
+                    closefd=False,
+                ),
+            )
+        except OSError:
+            return self.stream
+
+        return self.wrapped_stream
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self.wrapped_stream is not None:
+            self.wrapped_stream.close()
+
+
+def _stream_with_preserved_newlines(stream: TextIO, mode: str) -> AbstractContextManager[TextIO]:
+    return _StreamWithPreservedNewlines(stream, mode)
 
 
 def sort_imports(

--- a/isort/main.py
+++ b/isort/main.py
@@ -13,7 +13,7 @@ from dataclasses import asdict
 from gettext import gettext as _
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any, TextIO, cast
+from typing import Any, Literal, TextIO
 from warnings import warn
 
 from . import api, files, sections
@@ -54,24 +54,22 @@ class SortAttempt:
         return (self.__class__, (self.incorrectly_sorted, self.skipped, self.supported_encoding))
 
 
-def _stream_with_preserved_newlines(stream: TextIO, mode: str) -> AbstractContextManager[TextIO]:
-    if not isinstance(stream, TextIOWrapper):
-        return nullcontext(stream)
-
+def _stream_with_preserved_newlines(
+    stream: TextIO, *, mode: Literal["r", "w"]
+) -> AbstractContextManager[TextIO]:
     try:
-        return cast(
-            AbstractContextManager[TextIO],
-            open(
-                stream.fileno(),
-                mode,
-                encoding=stream.encoding,
-                errors=stream.errors,
-                newline="",
-                closefd=False,
-            ),
-        )
+        stream_fileno = stream.fileno()
     except OSError:
         return nullcontext(stream)
+
+    return open(
+        stream_fileno,
+        mode,
+        encoding=stream.encoding,
+        errors=stream.errors,
+        newline="",
+        closefd=False,
+    )
 
 
 def sort_imports(
@@ -1093,8 +1091,10 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
         if config.sort_reexports:
             sys.exit("Error: --sort-reexports is not supported with streaming input (stdin).")
 
-        raw_input_stream = sys.stdin if stdin is None else stdin
-        with _stream_with_preserved_newlines(raw_input_stream, "r") as input_stream:
+        with _stream_with_preserved_newlines(
+            sys.stdin if stdin is None else stdin,
+            mode="r",
+        ) as input_stream:
             if check:
                 incorrectly_sorted = not api.check_stream(
                     input_stream=input_stream,
@@ -1106,8 +1106,8 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
 
                 wrong_sorted_files = incorrectly_sorted
             else:
-                try:
-                    with _stream_with_preserved_newlines(sys.stdout, "w") as output_stream:
+                with _stream_with_preserved_newlines(sys.stdout, mode="w") as output_stream:
+                    try:
                         api.sort_stream(
                             input_stream=input_stream,
                             output_stream=output_stream,
@@ -1117,8 +1117,7 @@ def main(argv: Sequence[str] | None = None, stdin: TextIOWrapper | None = None) 
                             extension=ext_format,
                             raise_on_skip=False,
                         )
-                except FileSkipped:
-                    with _stream_with_preserved_newlines(sys.stdout, "w") as output_stream:
+                    except FileSkipped:
                         output_stream.write(input_stream.read())
     elif "/" in file_names and not allow_root:
         printer = create_terminal_printer(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -844,6 +844,30 @@ import a, b
     )
 
 
+def test_isort_with_stdin_preserves_lf_stdout(tmp_path):
+    input_content = TextIOWrapper(BytesIO(b"import re\nimport os\n"), newline=None)
+    output_file = tmp_path / "out.py"
+
+    with output_file.open("w", newline=None) as stdout:
+        with unittest.mock.patch("sys.stdout", stdout):
+            main.main(["-"], stdin=input_content)
+
+    assert output_file.read_bytes() == b"import os\nimport re\n"
+
+
+def test_isort_with_stdin_preserves_crlf_stdout(tmp_path):
+    input_file = tmp_path / "in.py"
+    input_file.write_bytes(b"import re\r\nimport os\r\n")
+    output_file = tmp_path / "out.py"
+
+    with input_file.open("r", newline=None) as input_content:
+        with output_file.open("w", newline=None) as stdout:
+            with unittest.mock.patch("sys.stdout", stdout):
+                main.main(["-"], stdin=input_content)
+
+    assert output_file.read_bytes() == b"import os\r\nimport re\r\n"
+
+
 def test_unsupported_encodings(tmpdir, capsys):
     tmp_file = tmpdir.join("file.py")
     # fmt: off

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -15,7 +15,7 @@ from isort._version import _VERSION_STRING, _IS_COMPILED
 from isort.exceptions import InvalidSettingsPath
 from isort.settings import DEFAULT_CONFIG, Config
 from .utils import as_stream
-from io import BytesIO, TextIOWrapper
+from io import BytesIO, StringIO, TextIOWrapper
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -866,6 +866,13 @@ def test_isort_with_stdin_preserves_crlf_stdout(tmp_path):
                 main.main(["-"], stdin=input_content)
 
     assert output_file.read_bytes() == b"import os\r\nimport re\r\n"
+
+
+def test_preserve_newline_stream_keeps_non_textiowrapper():
+    input_content = StringIO("import re\nimport os\n")
+
+    with main._stream_with_preserved_newlines(input_content, "r") as preserved_stream:
+        assert preserved_stream is input_content
 
 
 def test_unsupported_encodings(tmpdir, capsys):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import json
 import os
 import pathlib
@@ -844,7 +845,7 @@ import a, b
     )
 
 
-def test_isort_with_stdin_preserves_lf_stdout(tmp_path):
+def test_isort_with_stdin_preserves_lf_stdout(tmp_path: Path) -> None:
     input_content = TextIOWrapper(BytesIO(b"import re\nimport os\n"), newline=None)
     output_file = tmp_path / "out.py"
 
@@ -855,7 +856,7 @@ def test_isort_with_stdin_preserves_lf_stdout(tmp_path):
     assert output_file.read_bytes() == b"import os\nimport re\n"
 
 
-def test_isort_with_stdin_preserves_crlf_stdout(tmp_path):
+def test_isort_with_stdin_preserves_crlf_stdout(tmp_path: Path) -> None:
     input_file = tmp_path / "in.py"
     input_file.write_bytes(b"import re\r\nimport os\r\n")
     output_file = tmp_path / "out.py"
@@ -868,10 +869,10 @@ def test_isort_with_stdin_preserves_crlf_stdout(tmp_path):
     assert output_file.read_bytes() == b"import os\r\nimport re\r\n"
 
 
-def test_preserve_newline_stream_keeps_non_textiowrapper():
+def test_preserve_newline_stream_keeps_non_textiowrapper() -> None:
     input_content = StringIO("import re\nimport os\n")
 
-    with main._stream_with_preserved_newlines(input_content, "r") as preserved_stream:
+    with main._stream_with_preserved_newlines(input_content, mode="r") as preserved_stream:
         assert preserved_stream is input_content
 
 


### PR DESCRIPTION
Refs #2453.

When sorting stdin to stdout on Windows, Python's text-mode stdout can translate `\n` to `\r\n`. That makes LF input become CRLF output even when isort inferred LF from the input stream.

This writes stdin sorting output through a stdout wrapper with newline translation disabled, and adds a regression test for LF input written through a text stdout stream.

Tested with:

```powershell
python -m pytest tests/unit/test_main.py::test_isort_with_stdin_preserves_lf_stdout -q
python -m pytest tests/unit/test_main.py::test_isort_with_stdin -q
python -m ruff check isort/main.py tests/unit/test_main.py
python -m ruff format --check isort/main.py tests/unit/test_main.py
```