### PR TITLE
Small clean up and fix inconsistency in handling of `*` imports

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -615,8 +615,7 @@ def _with_from_imports_for_module(
 
     # Handle force_single_line
     if config.force_single_line and module not in config.single_line_exclusions:
-        while from_imports:
-            from_import = from_imports.pop(0)
+        for from_import in from_imports:
             single_import_line = with_comments(
                 comments,
                 import_start + from_import,
@@ -669,6 +668,7 @@ def _with_from_imports_for_module(
             else:
                 output.append(wrap.line(single_import_line, parsed.line_separator, config))
             comments = []
+        return output
 
     while from_imports:
         # Tracks whether any aliased imports were emitted before the grouped

--- a/isort/output.py
+++ b/isort/output.py
@@ -595,13 +595,20 @@ def _with_from_imports_for_module(
     if above_comments:
         output.extend(above_comments)
 
-    # Handle any * star import first if combine_star is enabled.
     only_show_as_imports = False
-    if "*" in from_imports and config.combine_star:
+    if "*" in from_imports:
+        from_imports.remove("*")
+
         output.append(
             wrap.line(
                 with_comments(
-                    _with_star_comments(parsed, module, list(comments or ())),
+                    _with_star_comments(
+                        parsed,
+                        module,
+                        # If we are combining the star imports we want to include all from-import
+                        # comments we found above.
+                        comments if config.combine_star else [],
+                    ),
                     f"{import_start}*",
                     removed=config.ignore_comments,
                     comment_prefix=config.comment_prefix,
@@ -610,8 +617,12 @@ def _with_from_imports_for_module(
                 config,
             )
         )
-        from_imports = [from_import for from_import in from_imports if from_import in as_imports]
-        only_show_as_imports = True
+
+        if config.combine_star:
+            from_imports = [
+                from_import for from_import in from_imports if from_import in as_imports
+            ]
+            only_show_as_imports = True
 
     # Handle force_single_line
     if config.force_single_line and module not in config.single_line_exclusions:
@@ -691,17 +702,6 @@ def _with_from_imports_for_module(
                     ),
                 )
             )
-
-        if "*" in from_imports:
-            output.append(
-                with_comments(
-                    _with_star_comments(parsed, module, []),
-                    f"{import_start}*",
-                    removed=config.ignore_comments,
-                    comment_prefix=config.comment_prefix,
-                )
-            )
-            from_imports.remove("*")
 
         for from_import in copy.copy(from_imports):
             comment = parsed.categorized_comments["nested"].get(module, {}).pop(from_import, None)

--- a/isort/output.py
+++ b/isort/output.py
@@ -616,23 +616,7 @@ def _with_from_imports_for_module(
     # Handle force_single_line
     if config.force_single_line and module not in config.single_line_exclusions:
         for from_import in from_imports:
-            single_import_line = with_comments(
-                comments,
-                import_start + from_import,
-                removed=config.ignore_comments,
-                comment_prefix=config.comment_prefix,
-            )
-            comment = parsed.categorized_comments["nested"].get(module, {}).pop(from_import, None)
-            if comment is not None:
-                comment_text = f" {comment}" if comment else ""
-                single_import_line += f"{(comments and ';') or config.comment_prefix}{comment_text}"
             if from_import in as_imports:
-                if (
-                    parsed.imports[section][import_key][module][from_import]
-                    and not only_show_as_imports
-                ):
-                    output.append(wrap.line(single_import_line, parsed.line_separator, config))
-
                 output.extend(
                     _build_as_imports(
                         from_import=from_import,
@@ -640,14 +624,36 @@ def _with_from_imports_for_module(
                         import_start=import_start,
                         line_separator=parsed.line_separator,
                         config=config,
-                        straight_comments=parsed.categorized_comments["straight"].get(
-                            f"{module}.{from_import}", []
-                        ),
+                        straight_comments=[
+                            *comments,
+                            *parsed.categorized_comments["straight"].get(
+                                f"{module}.{from_import}", []
+                            ),
+                        ],
                         nested_comments=parsed.categorized_comments["nested"].get(module, {}),
-                        include_straight_import=False,
+                        include_straight_import=(
+                            parsed.imports[section][import_key][module][from_import]
+                            and not only_show_as_imports
+                        ),
                     )
                 )
             else:
+                single_import_line = with_comments(
+                    [
+                        c
+                        for c in (
+                            *comments,
+                            parsed.categorized_comments["nested"]
+                            .get(module, {})
+                            .pop(from_import, None),
+                        )
+                        if c is not None
+                    ],
+                    import_start + from_import,
+                    removed=config.ignore_comments,
+                    comment_prefix=config.comment_prefix,
+                )
+
                 output.append(wrap.line(single_import_line, parsed.line_separator, config))
             comments = []
         return output

--- a/isort/output.py
+++ b/isort/output.py
@@ -632,39 +632,21 @@ def _with_from_imports_for_module(
                     and not only_show_as_imports
                 ):
                     output.append(wrap.line(single_import_line, parsed.line_separator, config))
-                from_comments = parsed.categorized_comments["straight"].get(
-                    f"{module}.{from_import}"
+
+                output.extend(
+                    _build_as_imports(
+                        from_import=from_import,
+                        as_imports=as_imports[from_import],
+                        import_start=import_start,
+                        line_separator=parsed.line_separator,
+                        config=config,
+                        straight_comments=parsed.categorized_comments["straight"].get(
+                            f"{module}.{from_import}", []
+                        ),
+                        nested_comments=parsed.categorized_comments["nested"].get(module, {}),
+                        include_straight_import=False,
+                    )
                 )
-
-                if not config.only_sections:
-                    output.extend(
-                        wrap.line(
-                            with_comments(
-                                from_comments,
-                                import_start + as_import,
-                                removed=config.ignore_comments,
-                                comment_prefix=config.comment_prefix,
-                            ),
-                            parsed.line_separator,
-                            config,
-                        )
-                        for as_import in sorting.sort(config, as_imports[from_import])
-                    )
-
-                else:
-                    output.extend(
-                        wrap.line(
-                            with_comments(
-                                from_comments,
-                                import_start + as_import,
-                                removed=config.ignore_comments,
-                                comment_prefix=config.comment_prefix,
-                            ),
-                            parsed.line_separator,
-                            config,
-                        )
-                        for as_import in as_imports[from_import]
-                    )
             else:
                 output.append(wrap.line(single_import_line, parsed.line_separator, config))
             comments = []

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -650,16 +650,42 @@ import os
     )
 
 
-def test_comments_should_never_be_moved_between_imports_issue_1427():
+def test_force_single_line_should_not_influence_order_of_star_import():
     """isort should never move comments to different import statement.
-    See: https://github.com/PyCQA/isort/issues/1427
+
+    Originally reported as an issue with moving comments across import statements,
+    see: https://github.com/PyCQA/isort/issues/1427
     """
+    expected = """from package import *  # noqa
+from package import CONSTANT
+"""
     assert isort.check_code(
-        """from package import CONSTANT
-from package import *  # noqa
-        """,
+        expected,
+        force_single_line=False,
+        show_diff=True,
+    )
+    assert isort.check_code(
+        expected,
         force_single_line=True,
         show_diff=True,
+    )
+    assert (
+        isort.code(
+            """from package import CONSTANT
+from package import *  # noqa
+""",
+            force_single_line=False,
+        )
+        == expected
+    )
+    assert (
+        isort.code(
+            """from package import CONSTANT
+from package import *  # noqa
+""",
+            force_single_line=True,
+        )
+        == expected
     )
 
 


### PR DESCRIPTION
While cleaning up for https://github.com/PyCQA/isort/pull/2614 I found an issue in the handling of `*` and `force_single_line`.
This is now fixed.