### PR TITLE
Docs: mention MegaLinter on the GitHub Action page

### DIFF
--- a/docs/configuration/github_action.md
+++ b/docs/configuration/github_action.md
@@ -61,3 +61,8 @@ jobs:
 [python-isort]: https://github.com/marketplace/actions/python-isort
 [checkout-action]: https://github.com/actions/checkout
 [setup-python]: https://github.com/actions/setup-python
+
+## Other CI tools
+
+isort is also available out of the box in [MegaLinter](https://megalinter.io/), an open-source aggregator that runs it together with other Python linters in most CI systems.
+See its [isort documentation page](https://megalinter.io/latest/descriptors/python_isort/) for setup details.


### PR DESCRIPTION
Hi! Small docs addition: a short "Other CI tools" note on the GitHub Action page pointing to [MegaLinter](https://megalinter.io/), where isort ships preinstalled alongside other Python linters ([descriptor page](https://megalinter.io/latest/descriptors/python_isort/)).

I maintain MegaLinter, so figured it could help isort users who run their CI through an aggregator. Happy to reword or move it elsewhere if you prefer!