### PR TITLE
Keep add_imports below a prefixed module docstring

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -47,6 +47,15 @@ def _strip_string_prefix(line: str) -> str:
     return line
 
 
+def _is_comment_or_string_start(line: str) -> bool:
+    """Return whether `line` opens a comment, a docstring or any other string literal.
+
+    A string prefix (`r`, `b`, `f`, `u` or a legal combination of them) is skipped
+    first, so a prefixed docstring is recognised exactly as an unprefixed one is.
+    """
+    return _strip_string_prefix(line.lstrip()).startswith(COMMENT_INDICATORS)
+
+
 def _has_skip_comment(import_statement: str) -> bool:
     """Return whether an import statement carries a per-line ``isort: skip`` directive."""
     return any(comment in import_statement for comment in SKIP_IMPORT_COMMENTS)
@@ -439,7 +448,7 @@ def process(
                 and not in_top_comment
                 and not was_in_quote
                 and not import_section
-                and not _strip_string_prefix(line.lstrip()).startswith(COMMENT_INDICATORS)
+                and not _is_comment_or_string_start(line)
                 and not (line.rstrip().endswith(DOCSTRING_INDICATORS) and "=" not in line)
             ):
                 add_line_separator = line_separator or "\n"

--- a/isort/core.py
+++ b/isort/core.py
@@ -20,6 +20,8 @@ IMPORT_START_IDENTIFIERS = (
 )
 DOCSTRING_INDICATORS = ('"""', "'''")
 COMMENT_INDICATORS = (*DOCSTRING_INDICATORS, "'", '"', "#")
+# Every legal Python string prefix, lower-cased; `u` cannot be combined with another.
+STRING_PREFIXES = frozenset(("r", "u", "f", "b", "fr", "rf", "br", "rb"))
 CODE_SORT_COMMENTS = (
     "# isort: list",
     "# isort: dict",
@@ -31,6 +33,17 @@ CODE_SORT_COMMENTS = (
 )
 LITERAL_TYPE_MAPPING = {"(": "tuple", "[": "list", "{": "set"}
 SKIP_IMPORT_COMMENTS = ("isort:skip", "isort: skip")
+
+
+def _strip_string_prefix(line: str) -> str:
+    """Return `line` without a leading Python string prefix (`r`, `b`, `f`, `u`
+    or a legal combination of them), so quote-based heuristics see the quote itself."""
+    for prefix_length in (2, 1):
+        if line[:prefix_length].lower() in STRING_PREFIXES and line[
+            prefix_length : prefix_length + 1
+        ] in ("'", '"'):
+            return line[prefix_length:]
+    return line
 
 
 def _has_skip_comment(import_statement: str) -> bool:
@@ -425,7 +438,7 @@ def process(
                 and not in_top_comment
                 and not was_in_quote
                 and not import_section
-                and not line.lstrip().startswith(COMMENT_INDICATORS)
+                and not _strip_string_prefix(line.lstrip()).startswith(COMMENT_INDICATORS)
                 and not (line.rstrip().endswith(DOCSTRING_INDICATORS) and "=" not in line)
             ):
                 add_line_separator = line_separator or "\n"

--- a/isort/core.py
+++ b/isort/core.py
@@ -37,7 +37,8 @@ SKIP_IMPORT_COMMENTS = ("isort:skip", "isort: skip")
 
 def _strip_string_prefix(line: str) -> str:
     """Return `line` without a leading Python string prefix (`r`, `b`, `f`, `u`
-    or a legal combination of them), so quote-based heuristics see the quote itself."""
+    or a legal combination of them), so quote-based heuristics see the quote itself.
+    """
     for prefix_length in (2, 1):
         if line[:prefix_length].lower() in STRING_PREFIXES and line[
             prefix_length : prefix_length + 1

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -6,6 +6,7 @@ import pytest
 
 import isort
 import isort.sections
+from isort.core import STRING_PREFIXES
 from isort.main import main
 
 
@@ -2463,9 +2464,11 @@ def test_add_import_keeps_a_prefixed_module_docstring_first_issue_1893():
         == 'r"""module docstring\n"""\n\nimport a\n\nx = 1\n'
     )
 
-    # Every legal prefix, in both quote flavours and both cases.
-    for prefix in ("r", "R", "b", "B", "f", "F", "u", "U", "rb", "bR", "Fr", "rf"):
-        for quote in ('"""', "'''"):
-            docstring = f"{prefix}{quote}module docstring\n{quote}\n"
-            source = docstring + "import a\n"
-            assert isort.code(source, add_imports=["import a"]) == source, prefix + quote
+    # Every prefix isort itself recognises, in both quote flavours and in lower,
+    # upper and mixed case.
+    for prefix in sorted(STRING_PREFIXES):
+        for cased in sorted({prefix, prefix.upper(), prefix.capitalize()}):
+            for quote in ('"""', "'''"):
+                docstring = f"{cased}{quote}module docstring\n{quote}\n"
+                source = docstring + "import a\n"
+                assert isort.code(source, add_imports=["import a"]) == source, cased + quote

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2443,3 +2443,29 @@ def test_isort_does_not_drop_aliased_import_when_plain_name_has_a_comment():
     expected = "from . import bar\nfrom . import one  # NOQA\nfrom . import one as zzz\n"
     assert relative_sorted == expected
     assert isort.code(relative_sorted) == relative_sorted
+
+
+def test_add_import_keeps_a_prefixed_module_docstring_first_issue_1893():
+    """``add_imports`` must not move an import above a module docstring that carries a
+    string prefix (``r``, ``b``, ``f``, ``u`` or a legal combination of them), as reported
+    in issue #1893: https://github.com/pycqa/isort/issues/1893
+    """
+    # The exact input from the report: the added import was emitted a second time, above
+    # the docstring.
+    reported = 'r"""module docstring\n"""\nfrom __future__ import annotations\n'
+    assert isort.code(reported, add_imports=["from __future__ import annotations"]) == reported
+
+    # The import still has to be added, below the docstring -- where an unprefixed
+    # docstring already puts it.
+    with_code = 'r"""module docstring\n"""\n\nx = 1\n'
+    assert (
+        isort.code(with_code, add_imports=["import a"])
+        == 'r"""module docstring\n"""\n\nimport a\n\nx = 1\n'
+    )
+
+    # Every legal prefix, in both quote flavours and both cases.
+    for prefix in ("r", "R", "b", "B", "f", "F", "u", "U", "rb", "bR", "Fr", "rf"):
+        for quote in ('"""', "'''"):
+            docstring = f"{prefix}{quote}module docstring\n{quote}\n"
+            source = docstring + "import a\n"
+            assert isort.code(source, add_imports=["import a"]) == source, prefix + quote


### PR DESCRIPTION
Closes #1893.

`add_imports` inserts the import *above* the module docstring when that docstring carries a string prefix:

```pycon
>>> import isort
>>> src = 'r\"\"\"module docstring\n\"\"\"\nfrom __future__ import annotations\n'
>>> print(isort.code(src, add_imports=["from __future__ import annotations"]))
from __future__ import annotations

r"""module docstring
"""
from __future__ import annotations
```

The import is both moved above the docstring and duplicated, because the file already contained it. Reported by @Skylion007 in 2022 and hit again by @sodul in 2024.

### Cause

The guard in `isort/core.py` that stops the insertion tests the raw line:

```python
and not line.lstrip().startswith(COMMENT_INDICATORS)
```

It only recognises a docstring that *begins* with a quote. `r"""...` begins with a letter, so the guard misses it and the import goes in above the docstring.

A single-line prefixed docstring escapes this by accident: the neighbouring `endswith(DOCSTRING_INDICATORS)` guard catches it. Only multi-line prefixed docstrings are affected. Every legal prefix and both quote flavours break; an unprefixed docstring never does.

(The report points at `isort/parse.py:218`; the actual place is the guard above.)

### Fix

A small helper that strips a legal string prefix, but only when a quote follows it immediately -- so ordinary identifiers like `rating = 1` are left alone.

### Tests

One regression test in `tests/unit/test_regressions.py`, three blocks: the reporter's exact input; a control that the import is *still added*, below the docstring; and a sweep over 12 prefixes x 2 quote flavours. It fails on `main` with the duplicated import shown above.

`pytest tests/unit` gives 615 passed with this change against 614 on a clean tree -- the same 3 failures in both runs (`test_importable` and two `test_ticketed_features` cases needing the example plugin packages), so no regressions. `flake8`, `ruff check`, `ruff format --check`, `isort --profile hug --check` and `mypy` are clean on both changed files.
