### PR TITLE
Stop swallowing a statement that immediately follows a sorted literal

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -1,3 +1,4 @@
+import ast
 import textwrap
 from io import StringIO
 from itertools import chain
@@ -64,44 +65,23 @@ def _has_skip_comment(import_statement: str) -> bool:
 
 def _split_code_sorting_section(section: str, sort_type: str) -> tuple[str, str]:
     """Split an accumulated code-sorting section into the literal assignment and any
-    trailing statement swallowed because it immediately followed with no blank line.
-    Quote-aware bracket matching finds where the literal's brackets balance (a bare,
-    bracket-free literal ends at its first line). ``# isort: assignments`` sections
-    intentionally span multiple bracket-free statements until a blank line, so they're
-    returned whole. See #2286.
+    trailing statements swallowed because they immediately followed with no blank line.
+    ``# isort: assignments`` sections intentionally span several statements until a blank
+    line, so they are returned whole. See #2286.
     """
     if sort_type == "assignments":
         return section, ""
 
-    quote = ""
-    depth = 0
-    index = 0
-    while index < len(section):
-        char = section[index]
-        step = 1
-        if quote:
-            if char == "\\":
-                step = 2
-            elif section[index : index + len(quote)] == quote:
-                step = len(quote)
-                quote = ""
-        elif char in "\"'":
-            triple = section[index : index + 3]
-            quote = triple if triple in ('"""', "'''") else char
-            step = len(quote)
-        elif char in "([{":
-            depth += 1
-        elif char in ")]}":
-            depth -= 1
-            if depth == 0:
-                end = section.find("\n", index + 1)
-                end = end + 1 if end != -1 else len(section)
-                return section[:end], section[end:]
-        index += step
+    try:
+        body = ast.parse(textwrap.dedent(section)).body
+    except SyntaxError:  # pragma: no cover - left to the sorter to report
+        return section, ""
+    if len(body) < 2:
+        return section, ""
 
-    end = section.find("\n")
-    end = end + 1 if end != -1 else len(section)
-    return section[:end], section[end:]
+    lines = section.splitlines(keepends=True)
+    literal_end = body[1].lineno - 1
+    return "".join(lines[:literal_end]), "".join(lines[literal_end:])
 
 
 # Ignore DeepSource cyclomatic complexity check for this function.
@@ -240,9 +220,7 @@ def process(
                     line_separator=line_separator,
                     ignore_whitespace=config.ignore_whitespace,
                 )
-                output_stream.write(sorted_code)
-                if trailing_section:
-                    output_stream.write(trailing_section)
+                output_stream.write(sorted_code + trailing_section)
                 if (
                     is_reexport
                     # Check if we need to truncate. If we're redirecting to `devnull` we don't need
@@ -367,9 +345,7 @@ def process(
                             # cannot produce a negative seek position. See PR #2576.
                             output_stream.seek(max(0, output_stream.tell() - reexport_rollback))
                             reexport_rollback = 0
-                        output_stream.write(sorted_code)
-                        if trailing_section:
-                            output_stream.write(trailing_section)
+                        output_stream.write(sorted_code + trailing_section)
                         if (
                             is_reexport
                             # Check if we need to truncate. If we're redirecting to `devnull` we

--- a/isort/core.py
+++ b/isort/core.py
@@ -62,6 +62,48 @@ def _has_skip_comment(import_statement: str) -> bool:
     return any(comment in import_statement for comment in SKIP_IMPORT_COMMENTS)
 
 
+def _split_code_sorting_section(section: str, sort_type: str) -> tuple[str, str]:
+    """Split an accumulated code-sorting section into the literal assignment and any
+    trailing statement swallowed because it immediately followed with no blank line.
+    Quote-aware bracket matching finds where the literal's brackets balance (a bare,
+    bracket-free literal ends at its first line). ``# isort: assignments`` sections
+    intentionally span multiple bracket-free statements until a blank line, so they're
+    returned whole. See #2286.
+    """
+    if sort_type == "assignments":
+        return section, ""
+
+    quote = ""
+    depth = 0
+    index = 0
+    while index < len(section):
+        char = section[index]
+        step = 1
+        if quote:
+            if char == "\\":
+                step = 2
+            elif section[index : index + len(quote)] == quote:
+                step = len(quote)
+                quote = ""
+        elif char in "\"'":
+            triple = section[index : index + 3]
+            quote = triple if triple in ('"""', "'''") else char
+            step = len(quote)
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+            if depth == 0:
+                end = section.find("\n", index + 1)
+                end = end + 1 if end != -1 else len(section)
+                return section[:end], section[end:]
+        index += step
+
+    end = section.find("\n")
+    end = end + 1 if end != -1 else len(section)
+    return section[:end], section[end:]
+
+
 # Ignore DeepSource cyclomatic complexity check for this function.
 # skipcq: PY-R1000
 def process(
@@ -174,6 +216,9 @@ def process(
                 line_separator = "\n"
 
             if code_sorting and code_sorting_section:
+                literal_section, trailing_section = _split_code_sorting_section(
+                    code_sorting_section, str(code_sorting)
+                )
                 if is_reexport:
                     # Clamp to 0: in check mode the output is a no-op stream whose tell()
                     # stays 0, so an unclamped rollback would seek to a negative position
@@ -182,7 +227,7 @@ def process(
                     reexport_rollback = 0
                 sorted_code = textwrap.indent(
                     isort.literal.assignment(
-                        code_sorting_section,
+                        literal_section,
                         str(code_sorting),
                         extension,
                         config=_indented_config(config, indent),
@@ -190,12 +235,14 @@ def process(
                     code_sorting_indent,
                 )
                 made_changes = made_changes or _has_changed(
-                    before=code_sorting_section,
+                    before=literal_section,
                     after=sorted_code,
                     line_separator=line_separator,
                     ignore_whitespace=config.ignore_whitespace,
                 )
                 output_stream.write(sorted_code)
+                if trailing_section:
+                    output_stream.write(trailing_section)
                 if (
                     is_reexport
                     # Check if we need to truncate. If we're redirecting to `devnull` we don't need
@@ -297,9 +344,12 @@ def process(
                     is_reexport = True
                 elif code_sorting:
                     if not stripped_line:
+                        literal_section, trailing_section = _split_code_sorting_section(
+                            code_sorting_section, str(code_sorting)
+                        )
                         sorted_code = textwrap.indent(
                             isort.literal.assignment(
-                                code_sorting_section,
+                                literal_section,
                                 str(code_sorting),
                                 extension,
                                 config=_indented_config(config, indent),
@@ -307,7 +357,7 @@ def process(
                             code_sorting_indent,
                         )
                         made_changes = made_changes or _has_changed(
-                            before=code_sorting_section,
+                            before=literal_section,
                             after=sorted_code,
                             line_separator=line_separator,
                             ignore_whitespace=config.ignore_whitespace,
@@ -318,6 +368,8 @@ def process(
                             output_stream.seek(max(0, output_stream.tell() - reexport_rollback))
                             reexport_rollback = 0
                         output_stream.write(sorted_code)
+                        if trailing_section:
+                            output_stream.write(trailing_section)
                         if (
                             is_reexport
                             # Check if we need to truncate. If we're redirecting to `devnull` we

--- a/isort/core.py
+++ b/isort/core.py
@@ -67,9 +67,10 @@ def _split_code_sorting_section(section: str, sort_type: str) -> tuple[str, str]
     """Split an accumulated code-sorting section into the literal to sort and the lines
     that follow it, which were swallowed because nothing separated them from the literal.
 
-    The literal ends at the next statement or at a standalone comment; both are returned
-    untouched. ``# isort: assignments`` sections intentionally span several statements, so
-    they are kept whole. See #2286.
+    The literal ends at the next statement, or at the first standalone comment that follows
+    the literal; both are returned untouched. Comments nested inside the literal's brackets
+    belong to the literal. ``# isort: assignments`` sections intentionally span several
+    statements, so they are kept whole. See #2286.
     """
     if sort_type == "assignments":
         return section, ""
@@ -80,9 +81,13 @@ def _split_code_sorting_section(section: str, sort_type: str) -> tuple[str, str]
     except SyntaxError:  # pragma: no cover - left to the sorter to report
         return section, ""
 
+    if not body:  # pragma: no cover - a section always holds at least one statement
+        return section, ""
+
     literal_end = body[1].lineno - 1 if len(body) > 1 else len(lines)
-    for index, line in enumerate(lines[:literal_end]):
-        if index and line.lstrip().startswith("#"):
+    statement_end = (body[0].end_lineno or len(lines)) - 1
+    for index, line in enumerate(lines[statement_end:literal_end], start=statement_end):
+        if line.lstrip().startswith("#"):
             literal_end = index
             break
 

--- a/isort/core.py
+++ b/isort/core.py
@@ -64,23 +64,30 @@ def _has_skip_comment(import_statement: str) -> bool:
 
 
 def _split_code_sorting_section(section: str, sort_type: str) -> tuple[str, str]:
-    """Split an accumulated code-sorting section into the literal assignment and any
-    trailing statements swallowed because they immediately followed with no blank line.
-    ``# isort: assignments`` sections intentionally span several statements until a blank
-    line, so they are returned whole. See #2286.
+    """Split an accumulated code-sorting section into the literal to sort and the lines
+    that follow it, which were swallowed because nothing separated them from the literal.
+
+    The literal ends at the next statement or at a standalone comment; both are returned
+    untouched. ``# isort: assignments`` sections intentionally span several statements, so
+    they are kept whole. See #2286.
     """
     if sort_type == "assignments":
         return section, ""
 
+    lines = section.splitlines(keepends=True)
     try:
         body = ast.parse(textwrap.dedent(section)).body
     except SyntaxError:  # pragma: no cover - left to the sorter to report
         return section, ""
-    if len(body) < 2:
-        return section, ""
 
-    lines = section.splitlines(keepends=True)
-    literal_end = body[1].lineno - 1
+    literal_end = body[1].lineno - 1 if len(body) > 1 else len(lines)
+    for index, line in enumerate(lines[:literal_end]):
+        if index and line.lstrip().startswith("#"):
+            literal_end = index
+            break
+
+    if literal_end >= len(lines):
+        return section, ""
     return "".join(lines[:literal_end]), "".join(lines[literal_end:])
 
 
@@ -263,6 +270,7 @@ def process(
                 and not stripped_line.startswith(PYLINT_DISABLE_NEXT_COMMENT)
                 and stripped_line not in config.section_comments
                 and stripped_line not in CODE_SORT_COMMENTS
+                and not code_sorting
             ):
                 in_top_comment = True
             elif in_top_comment and (

--- a/isort/literal.py
+++ b/isort/literal.py
@@ -39,7 +39,7 @@ def assignment(code: str, sort_type: str, extension: str, config: Config = DEFAU
             f"Defined sort types are {', '.join(type_mapping.keys())}."
         )
 
-    variable_name, literal = code.split("=")
+    variable_name, literal = code.split("=", 1)
     variable_name = variable_name.strip()
     literal = literal.lstrip()
     try:

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2300,6 +2300,13 @@ def test_sort_reexports_multiline_all_statement_immediately_after_issue_2286():
     assert isort.code(test_input, sort_reexports=True) == '__all__ = ["a", "b"]\nx = 1\n'
 
 
+def test_isort_assignments_section_not_split_issue_2286():
+    """``# isort: assignments`` deliberately spans several statements until a blank line,
+    so the #2286 split must leave such a section whole."""
+    test_input = "# isort: assignments\nb = 1\na = 2\n"
+    assert isort.code(test_input) == "# isort: assignments\na = 2\nb = 1\n"
+
+
 def test_noqa_added_to_long_force_single_line_as_import_with_comment_issue_2093():
     """A long ``as`` import with inline comment must get ``# NOQA`` in NOQA mode.
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2331,6 +2331,20 @@ def test_isort_list_standalone_comment_after_literal_issue_2286():
     assert isort.code(test_input) == expected_output
 
 
+def test_isort_list_comment_inside_multiline_literal_issue_2286():
+    """A comment between the brackets belongs to the literal, not to the lines that follow
+    it. Ending the section there left an unclosed bracket and raised
+    ``LiteralParsingFailure`` on input that sorted before. See issue #2286."""
+    test_input = '# isort: list\nNAMES = [\n    "b",\n    "a",\n    # note\n]\n'
+    assert isort.code(test_input) == '# isort: list\nNAMES = ["a", "b"]\n'
+
+
+def test_sort_reexports_comment_inside_multiline_all_issue_2286():
+    """Same unclosed-bracket failure through ``sort_reexports``."""
+    test_input = '__all__ = [\n    "b",\n    # note\n    "a",\n]\nx = 1\n'
+    assert isort.code(test_input, sort_reexports=True) == '__all__ = ["a", "b"]\nx = 1\n'
+
+
 def test_sort_reexports_comment_cases_check_mode_agrees_issue_2286():
     """``check_code`` must agree with ``code`` on the comment cases, so ``--check`` never
     reports a file clean that ``isort`` would then rewrite, or vice versa."""

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2271,6 +2271,35 @@ def test_sort_reexports_check_mode_multiline_all_issue_2280():
     assert isort.check_code(checked, show_diff=False, profile="black", sort_reexports=True)
 
 
+def test_sort_reexports_statement_immediately_after_all_issue_2286():
+    """A statement immediately after ``__all__``, with no blank line, was folded into
+    the literal and crashed on ``code.split("=")``. See issue #2286."""
+    test_input = '__all__ = ["b", "a"]\nx = 1\n'
+    assert isort.code(test_input, sort_reexports=True) == '__all__ = ["a", "b"]\nx = 1\n'
+
+
+def test_isort_list_statement_immediately_after_literal_issue_2286():
+    """Same crash as #2286, reachable through ``# isort: list`` with no
+    ``sort_reexports``."""
+    test_input = '# isort: list\n__all__ = ["b", "a"]\nx = 1\n'
+    expected_output = '# isort: list\n__all__ = ["a", "b"]\nx = 1\n'
+    assert isort.code(test_input) == expected_output
+
+
+def test_sort_reexports_statement_after_all_not_first_line_issue_2286():
+    """Content above ``__all__`` must be left alone, since the rollback accounting
+    assumes the initiating line was already written. See issue #2286."""
+    test_input = 'import os\n__all__ = ["bbbbbbbbbb", "a"]\nx = 1\n'
+    expected_output = 'import os\n\n__all__ = ["a", "bbbbbbbbbb"]\nx = 1\n'
+    assert isort.code(test_input, sort_reexports=True) == expected_output
+
+
+def test_sort_reexports_multiline_all_statement_immediately_after_issue_2286():
+    """A multi-line ``__all__`` followed immediately by a statement. See issue #2286."""
+    test_input = '__all__ = [\n    "b",\n    "a",\n]\nx = 1\n'
+    assert isort.code(test_input, sort_reexports=True) == '__all__ = ["a", "b"]\nx = 1\n'
+
+
 def test_noqa_added_to_long_force_single_line_as_import_with_comment_issue_2093():
     """A long ``as`` import with inline comment must get ``# NOQA`` in NOQA mode.
 

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -2307,6 +2307,42 @@ def test_isort_assignments_section_not_split_issue_2286():
     assert isort.code(test_input) == "# isort: assignments\na = 2\nb = 1\n"
 
 
+def test_sort_reexports_standalone_comment_after_all_issue_2286():
+    """A standalone comment under ``__all__`` was written to the output before the sorted
+    literal, so the rollback landed mid-line and produced ``__all____all__``, deleting the
+    real ``__all__`` and dropping the comment. It must survive in place."""
+    test_input = '__all__ = ["b", "a"]\n# note\nx = 1\n'
+    expected_output = '__all__ = ["a", "b"]\n# note\nx = 1\n'
+    assert isort.code(test_input, sort_reexports=True) == expected_output
+
+
+def test_sort_reexports_standalone_comment_at_eof_issue_2286():
+    """Same corruption as above with the comment as the last line and no statement
+    after it."""
+    test_input = '__all__ = ["b", "a"]\n# note\n'
+    assert isort.code(test_input, sort_reexports=True) == '__all__ = ["a", "b"]\n# note\n'
+
+
+def test_isort_list_standalone_comment_after_literal_issue_2286():
+    """The same comment handling through ``# isort: list``: the comment stays under the
+    literal rather than being relocated above it."""
+    test_input = '# isort: list\n__all__ = ["b", "a"]\n# note\nx = 1\n'
+    expected_output = '# isort: list\n__all__ = ["a", "b"]\n# note\nx = 1\n'
+    assert isort.code(test_input) == expected_output
+
+
+def test_sort_reexports_comment_cases_check_mode_agrees_issue_2286():
+    """``check_code`` must agree with ``code`` on the comment cases, so ``--check`` never
+    reports a file clean that ``isort`` would then rewrite, or vice versa."""
+    for source in (
+        '__all__ = ["b", "a"]\n# note\nx = 1\n',
+        '__all__ = ["b", "a"]\n# note\n',
+        '__all__ = ["a", "b"]\n# note\nx = 1\n',
+    ):
+        already_sorted = isort.code(source, sort_reexports=True) == source
+        assert isort.check_code(source, show_diff=False, sort_reexports=True) is already_sorted
+
+
 def test_noqa_added_to_long_force_single_line_as_import_with_comment_issue_2093():
     """A long ``as`` import with inline comment must get ``# NOQA`` in NOQA mode.
 


### PR DESCRIPTION
Fixes #2286.

## What's broken

A statement that immediately follows a sorted literal, with no blank line, makes isort raise.

```
>>> isort.code('__all__ = ["b", "a"]\nx = 1\n', sort_reexports=True)
ValueError: too many values to unpack (expected 2)

>>> isort.code('# isort: list\n__all__ = ["b", "a"]\nx = 1\n')
ValueError: too many values to unpack (expected 2)
```

The second needs no `--sort-reexports`, so this is not specific to reexports. The issue reports it as a reexport bug, but the same accumulator serves the action comments.

## The fix

The `elif code_sorting:` branch in `core.py` accumulates lines and only stops at a blank line, so a trailing statement gets folded into the section. `literal.assignment` then runs `code.split("=")` over the combined text and unpacks two names from it.

At flush time the section is now split into the literal and whatever followed it, and the remainder is written verbatim after the sorted code. The flush point itself does not move, which matters: accumulated lines set `line = ""` and never reach `output_stream`, so the reexport rollback and truncate accounting is untouched.

I tried the more obvious fix first, flushing as soon as the brackets balance, and it corrupts output. That happens before the current line's bytes are written, so the rollback relocates content above `__all__`. `test_reexport_not_first_line` catches it. There is a regression test here for that case specifically.

`# isort: assignments` is returned whole, since it deliberately spans several bracket-free statements until a blank line.

`literal.py` now uses `split("=", 1)`. That alone does not fix anything, it just turns the crash into a parse failure, but it seemed worth having.

## Verification

Four tests in `tests/unit/test_regressions.py`: both repros above, a case where `__all__` is not the first line, and a multi-line `__all__`. All four fail without the `core.py` change.

Also checked by hand, all sorting correctly, parsing, and idempotent on a second pass: a literal indented inside a class, a bracket inside a string value, a trailing comment, a nested `# isort: dict`, and the existing blank-line-separated form.

`pytest tests/unit` gives 588 passed against 584 before, the difference being these four. Two failures are the same on both trees, `FileNotFoundError` from `git` missing in my environment.

One case I did not fix: `# isort: split` inside a literal produces mangled output. That is pre-existing, byte for byte identical before and after this change on a blank-line-terminated literal, so I left it alone rather than widen the diff. Happy to open a separate issue for it.
