### PR TITLE
Fix pylint disable-next comments at the start of imports

### DIFF
--- a/isort/core.py
+++ b/isort/core.py
@@ -30,6 +30,7 @@ CODE_SORT_COMMENTS = (
     "# isort: assignments",
 )
 LITERAL_TYPE_MAPPING = {"(": "tuple", "[": "list", "{": "set"}
+PYLINT_DISABLE_NEXT_COMMENT = "# pylint: disable-next"
 SKIP_IMPORT_COMMENTS = ("isort:skip", "isort: skip")
 
 
@@ -211,6 +212,7 @@ def process(
             if (
                 (index == 0 or (index in {1, 2} and not contains_imports))
                 and stripped_line.startswith("#")
+                and not stripped_line.startswith(PYLINT_DISABLE_NEXT_COMMENT)
                 and stripped_line not in config.section_comments
                 and stripped_line not in CODE_SORT_COMMENTS
             ):

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -45,6 +45,23 @@ def test_moving_comments_issue_726():
     assert isort.code(test_input, force_sort_within_sections=True) == test_input
 
 
+def test_pylint_disable_next_stays_with_first_import_issue_2054():
+    test_input = (
+        "# pylint: disable-next=no-name-in-module\n"
+        "from C import D\n"
+        "# pylint: disable-next=no-name-in-module\n"
+        "from A import B\n"
+    )
+    expected_output = (
+        "# pylint: disable-next=no-name-in-module\n"
+        "from A import B\n"
+        "# pylint: disable-next=no-name-in-module\n"
+        "from C import D\n"
+    )
+
+    assert isort.code(test_input) == expected_output
+
+
 def test_blank_lined_removed_issue_1275():
     """Ensure isort doesn't accidentally remove blank lines after doc strings and before imports.
     See: https://github.com/pycqa/isort/issues/1275

--- a/tests/unit/test_regressions.py
+++ b/tests/unit/test_regressions.py
@@ -47,7 +47,7 @@ def test_moving_comments_issue_726():
 
 def test_pylint_disable_next_stays_with_first_import_issue_2054():
     test_input = (
-        "# pylint: disable-next=no-name-in-module\n"
+        "# pylint: disable-next=import-error\n"
         "from C import D\n"
         "# pylint: disable-next=no-name-in-module\n"
         "from A import B\n"
@@ -55,7 +55,7 @@ def test_pylint_disable_next_stays_with_first_import_issue_2054():
     expected_output = (
         "# pylint: disable-next=no-name-in-module\n"
         "from A import B\n"
-        "# pylint: disable-next=no-name-in-module\n"
+        "# pylint: disable-next=import-error\n"
         "from C import D\n"
     )
 


### PR DESCRIPTION
## Summary
- keep a leading `pylint: disable-next` directive with the import it governs
- add a regression test for sorting two such from-imports

Closes #2054

## Testing
- `uv run pytest tests/unit/test_regressions.py`
- `uv run tox -e py3.13`