### PR TITLE
Use `cibuildwheel` to build wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,88 @@
+---
+name: Build
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: github.repository_owner == 'PyCQA'
+    name: Build sdist and non-compiled wheel
+    runs-on: ubuntu-latest
+    
+    steps:
+      - &checkout
+        name: Check out the repository
+        uses: actions/checkout@v7
+        with:
+          # To ensure hatch-vcs can get the correct version from the git history.
+          fetch-depth: 0
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v7
+        with:
+          python-version: 3.14
+          check-latest: true
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          version-file: "pyproject.toml"
+
+      - name: Build sdist and wheel
+        env:
+            HATCH_BUILD_HOOK_ENABLE_MYPYC: false
+        run: uv build
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v7.0.1
+        with:
+            name: cibw-sdist
+            path: dist/*.tar.gz
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7.0.1
+        with:
+            name: cibw-wheel-pure
+            path: dist/*.whl
+
+  build_wheels:
+    name: Build wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runs-on: ubuntu-latest
+          - os: windows-latest
+            runs-on: windows-latest
+          - os: macos-latest
+            runs-on: macos-latest
+          - os: pyodide
+            runs-on: ubuntu-latest
+            platform: pyodide
+
+    steps:
+      - *checkout
+
+      - name: Build wheels
+        env:
+          CIBW_ENVIRONMENT: "HATCH_BUILD_HOOK_ENABLE_MYPYC=true"
+          CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
+          CIBW_SKIP: "*-win32"
+        uses: pypa/cibuildwheel@v4.2.0
+
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: cibw-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,26 +46,6 @@ jobs:
       - name: Lint
         run: uv run --with tox-uv tox -e lint
 
-  build:
-    if: github.repository_owner == 'PyCQA'
-    name: Build
-    runs-on: ubuntu-latest
-    
-    steps:
-      - *checkout
-      - *setup-python
-      - *setup-uv
-
-      - name: Build package and wheel
-        env:
-            HATCH_BUILD_HOOK_ENABLE_MYPYC: false
-        run: uv build
-
-      - name: Build package and compiled wheel
-        env:
-          HATCH_BUILD_HOOK_ENABLE_MYPYC: true
-        run: uv build
-
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,38 +8,7 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == 'PyCQA'
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.14"
-
-      - name: Install UV
-        uses: astral-sh/setup-uv@v7
-        with:
-          version-file: "pyproject.toml"
-
-      - name: Install dependencies
-        run: |
-          uv sync --all-extras --frozen
-
-      - name: Build package
-        run: |
-          uv build
-
-      - name: Upload release assets
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: release-assets
-          path: dist/
+    uses: ./.github/workflows/build.yml
 
   release-pypi:
     name: Upload release to PyPI
@@ -51,10 +20,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Download release assets
+      - &download-release-assets
+        name: Download release assets
         uses: actions/download-artifact@v8.0.1
         with:
           name: release-assets
+          pattern: cibw-*
           path: dist/
 
       - name: Publish package on PyPI
@@ -69,11 +40,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Download release assets
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: release-assets
-          path: dist/
+      - *download-release-assets
       - name: Sign the dists with Sigstore and upload assets to Github release
         if: github.event_name == 'release'
         uses: sigstore/gh-action-sigstore-python@v3.5.0


### PR DESCRIPTION
References https://github.com/PyCQA/isort/issues/1953

Next step is to ensure we build compiled wheels for all "supported" platforms. I think `cibuildwheel` is how we are supposed to do this, but it is a bit tricky to figure out exactly what the correct syntax looks like. Let's see if this work I guess?