### PR TITLE
Remove `name` from downloading assets steps in Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         name: Download release assets
         uses: actions/download-artifact@v8.0.1
         with:
-          name: release-assets
           pattern: cibw-*
           path: dist/
 


### PR DESCRIPTION
This broke releaseing of `9.0.0b3`. See https://github.com/PyCQA/isort/actions/runs/31974686804

This is why we have betas :)