### PR TITLE
Add `merge-multiple` when downloading release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@ jobs:
         name: Download release assets
         uses: actions/download-artifact@v8.0.1
         with:
-          pattern: cibw-*
+          merge-multiple: true
           path: dist/
+          pattern: cibw-*
 
       - name: Publish package on PyPI
         if: github.event_name == 'release'


### PR DESCRIPTION
9.0.0b4 also failed to release successfully...

Why is Github Actions such a struggle...
Let's try this again!