### PR TITLE
Clarify src path help text

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -793,9 +793,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--src-path",
         dest="src_paths",
         action="append",
-        help="Add an explicitly defined source path "
-        "(modules within src paths have their imports automatically categorized as first_party)."
-        " Glob expansion (`*` and `**`) is supported for this option.",
+        help="Add an explicitly defined source path. "
+        "Modules found within source paths are automatically categorized as first_party. "
+        "Glob expansion (`*` and `**`) is supported for this option.",
     )
     section_group.add_argument(
         "-b",


### PR DESCRIPTION
## Summary

Clarify the `--src-path` help text to make the behavior of configured
source paths easier to understand.

## Changes

- Clarify that modules found within configured source paths are automatically
  categorized as `first_party`.
- No classification logic or behavior was changed.

## Testing

- `pytest tests/unit/test_place.py`
- 4 passed